### PR TITLE
Desktop UI structural and readability repair

### DIFF
--- a/index.html
+++ b/index.html
@@ -419,39 +419,44 @@
                         <div id="plannerTrackedStatState" class="plannerStatusPill"></div>
                         <div id="plannerSelectionState" class="plannerStatusPill"></div>
                     </div>
-                    <div id="plannerMetaBar">
-                        <div id="plannerPredictorPanel">
-                            <div id="plannerPredictorHeading" class="plannerMetaHeading"></div>
-                            <div id="plannerPredictorSummary">
-                                <span id="predictorTotalDisplay" class="koviko"></span>
-                                <span id="predictorStatisticDisplay" class="koviko"></span>
-                            </div>
-                            <div id="plannerPredictorControls">
-                                <label for="predictorTrackedStatInput" id="plannerTrackedStatLabel"></label>
-                                <select id='predictorTrackedStatInput' class='button' onchange="view.handlePredictorTrackedStatChange(this.value)"></select>
-                            </div>
-                            <div id="plannerTrackedStatHint" class="plannerHelperText"></div>
-                        </div>
-                        <div id="plannerViewControls">
-                            <div id="plannerViewHeading" class="plannerMetaHeading"></div>
-                            <button
-                                id="plannerViewToggle"
-                                type="button"
-                                class="button plannerToggleButton plannerViewToggle"
-                                onclick="view.togglePlannerViewMenu()"
-                                aria-expanded="false"
-                            ></button>
-                            <div id="plannerViewControlBody" class="plannerViewControlBody hidden">
-                                <div id="plannerPresetBar" class="plannerPresetBar" role="group" aria-label="UI Presets">
-                                    <button id="uiPresetClassic" type="button" class="button plannerPresetButton" onclick="view.setUiPreset('classic')"></button>
-                                    <button id="uiPresetPlanner" type="button" class="button plannerPresetButton" onclick="view.setUiPreset('planner')"></button>
-                                    <button id="uiPresetReader" type="button" class="button plannerPresetButton" onclick="view.setUiPreset('reader')"></button>
-                                    <button id="uiPresetCompact" type="button" class="button plannerPresetButton" onclick="view.setUiPreset('compact')"></button>
+                    <details id="plannerMetaBarDetails" class="actionChangeAccordion">
+                        <summary id="plannerMetaBarSummary" class="actionChangeAccordionTitle" style="font-weight: bold; background: color-mix(in srgb, var(--body-background) 80%, var(--default-color) 20%); padding: 5px; border-radius: 5px;">
+                            Advanced Controls / 高级控制
+                        </summary>
+                        <div id="plannerMetaBar">
+                            <div id="plannerPredictorPanel">
+                                <div id="plannerPredictorHeading" class="plannerMetaHeading"></div>
+                                <div id="plannerPredictorSummary">
+                                    <span id="predictorTotalDisplay" class="koviko"></span>
+                                    <span id="predictorStatisticDisplay" class="koviko"></span>
                                 </div>
-                                <button id="queueRepeatToggle" type="button" class="button plannerToggleButton" onclick="view.toggleQueueCompactRepeats()"></button>
+                                <div id="plannerPredictorControls">
+                                    <label for="predictorTrackedStatInput" id="plannerTrackedStatLabel"></label>
+                                    <select id='predictorTrackedStatInput' class='button' onchange="view.handlePredictorTrackedStatChange(this.value)"></select>
+                                </div>
+                                <div id="plannerTrackedStatHint" class="plannerHelperText"></div>
+                            </div>
+                            <div id="plannerViewControls">
+                                <div id="plannerViewHeading" class="plannerMetaHeading"></div>
+                                <button
+                                    id="plannerViewToggle"
+                                    type="button"
+                                    class="button plannerToggleButton plannerViewToggle"
+                                    onclick="view.togglePlannerViewMenu()"
+                                    aria-expanded="false"
+                                ></button>
+                                <div id="plannerViewControlBody" class="plannerViewControlBody hidden">
+                                    <div id="plannerPresetBar" class="plannerPresetBar" role="group" aria-label="UI Presets">
+                                        <button id="uiPresetClassic" type="button" class="button plannerPresetButton" onclick="view.setUiPreset('classic')"></button>
+                                        <button id="uiPresetPlanner" type="button" class="button plannerPresetButton" onclick="view.setUiPreset('planner')"></button>
+                                        <button id="uiPresetReader" type="button" class="button plannerPresetButton" onclick="view.setUiPreset('reader')"></button>
+                                        <button id="uiPresetCompact" type="button" class="button plannerPresetButton" onclick="view.setUiPreset('compact')"></button>
+                                    </div>
+                                    <button id="queueRepeatToggle" type="button" class="button plannerToggleButton" onclick="view.toggleQueueCompactRepeats()"></button>
+                                </div>
                             </div>
                         </div>
-                    </div>
+                    </details>
                     <div id="plannerControls">
                         <div id="nextActionsAmountButtons">
                             <div class="plannerAmountLabel bold localized" data-lockey="actions>tooltip>amount"></div>
@@ -462,7 +467,7 @@
                                 <input id="amountCustom" oninput="setCustomActionAmount()" onblur="setCustomActionAmount()" value="1">
                             </div>
                         </div>
-                    </details>
+                    </div>
                 </div>
                 <div id="expandableList">
                     <div id="curActionsListContainer">

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -4553,8 +4553,8 @@ body.ui-density-large .chronicleStoryUnread {
         display:grid;
         grid:
             "header header header" max-content
-            "actions town stats" minmax(0, 1fr)
-            / minmax(300px, 1.08fr) minmax(600px, 1.58fr) minmax(340px, 1.16fr)
+            "stats actions town" minmax(0, 1fr)
+            / minmax(340px, 1fr) minmax(600px, 2fr) minmax(340px, 1fr)
             ;
         justify-items: stretch;
     }


### PR DESCRIPTION
This PR addresses the desktop UI repair priorities for omsi-loops. It reduces top-bar bulk by collapsing advanced controls (planner, predictor, presets) into a native accordion while keeping the action amount controls visible. It reshapes the 3-column desktop layout to ensure the main actions area is dead-center and proportionally dominant, vastly improving the readability and focus.

Visual/Structural modifications:
- `index.html`: Wrapped `#plannerMetaBar` in `<details id="plannerMetaBarDetails" class="actionChangeAccordion">`. Removed mismatched `</details>` and fixed `#plannerControls` closure.
- `stylesheet.css`: Updated `#mainColumn` desktop grids to use `"stats actions town"` instead of `"actions town stats"`, and bumped the middle column width to `2fr` for primary stage focus.

Test/Validation:
- Tested with local static server. Visually confirmed grid rearrangement and `<details>` collapsible function.
- `npm run smoke` - passed.
- `npm run fixtures:review` - generated and verified successfully.
- No temporary files or test outputs (`results.json`) are tracked in this commit.

---
*PR created automatically by Jules for task [9761103534874561995](https://jules.google.com/task/9761103534874561995) started by @wenhuorongbing-netizen*