### PR TITLE
Refactor desktop advanced controls into accordions and fix layout nesting

### DIFF
--- a/index.html
+++ b/index.html
@@ -422,42 +422,6 @@
                         <div id="plannerTrackedStatState" class="plannerStatusPill"></div>
                         <div id="plannerSelectionState" class="plannerStatusPill"></div>
                     </div>
-                    <details id="plannerMetaBarDetails">
-                        <summary>Advanced Planner Rules</summary>
-                    <div id="plannerMetaBar">
-                        <div id="plannerPredictorPanel">
-                            <div id="plannerPredictorHeading" class="plannerMetaHeading"></div>
-                            <div id="plannerPredictorSummary">
-                                <span id="predictorTotalDisplay" class="koviko"></span>
-                                <span id="predictorStatisticDisplay" class="koviko"></span>
-                            </div>
-                            <div id="plannerPredictorControls">
-                                <label for="predictorTrackedStatInput" id="plannerTrackedStatLabel"></label>
-                                <select id='predictorTrackedStatInput' class='button' onchange="view.handlePredictorTrackedStatChange(this.value)"></select>
-                            </div>
-                            <div id="plannerTrackedStatHint" class="plannerHelperText"></div>
-                        </div>
-                        <div id="plannerViewControls">
-                            <div id="plannerViewHeading" class="plannerMetaHeading"></div>
-                            <button
-                                id="plannerViewToggle"
-                                type="button"
-                                class="button plannerToggleButton plannerViewToggle"
-                                onclick="view.togglePlannerViewMenu()"
-                                aria-expanded="false"
-                            ></button>
-                            <div id="plannerViewControlBody" class="plannerViewControlBody hidden">
-                                <div id="plannerPresetBar" class="plannerPresetBar" role="group" aria-label="UI Presets">
-                                    <button id="uiPresetClassic" type="button" class="button plannerPresetButton" onclick="view.setUiPreset('classic')"></button>
-                                    <button id="uiPresetPlanner" type="button" class="button plannerPresetButton" onclick="view.setUiPreset('planner')"></button>
-                                    <button id="uiPresetReader" type="button" class="button plannerPresetButton" onclick="view.setUiPreset('reader')"></button>
-                                    <button id="uiPresetCompact" type="button" class="button plannerPresetButton" onclick="view.setUiPreset('compact')"></button>
-                                </div>
-                                <button id="queueRepeatToggle" type="button" class="button plannerToggleButton" onclick="view.toggleQueueCompactRepeats()"></button>
-                            </div>
-                        </div>
-                    </div>
-                    </details>
                     <div id="plannerControls">
                         <div id="nextActionsAmountButtons">
                             <div class="plannerAmountLabel bold localized" data-lockey="actions>tooltip>amount"></div>
@@ -468,8 +432,33 @@
                                 <input id="amountCustom" oninput="setCustomActionAmount()" onblur="setCustomActionAmount()" value="1">
                             </div>
                         </div>
-                    </details>
-                </div>
+                        <details id="plannerPredictorPanel" class="actionChangeCard actionChangeAccordion">
+                            <summary id="plannerPredictorHeading" class="actionChangeCardTitle actionChangeAccordionTitle"></summary>
+                            <div class="actionChangeAccordionBody">
+                                <div id="plannerPredictorSummary">
+                                    <span id="predictorTotalDisplay" class="koviko"></span>
+                                    <span id="predictorStatisticDisplay" class="koviko"></span>
+                                </div>
+                                <div id="plannerPredictorControls">
+                                    <label for="predictorTrackedStatInput" id="plannerTrackedStatLabel"></label>
+                                    <select id='predictorTrackedStatInput' class='button' onchange="view.handlePredictorTrackedStatChange(this.value)"></select>
+                                </div>
+                                <div id="plannerTrackedStatHint" class="plannerHelperText"></div>
+                            </div>
+                        </details>
+                        <details id="plannerViewControls" class="actionChangeCard actionChangeAccordion">
+                            <summary id="plannerViewHeading" class="actionChangeCardTitle actionChangeAccordionTitle"></summary>
+                            <div class="actionChangeAccordionBody" id="plannerViewControlBody">
+                                <div id="plannerPresetBar" class="plannerPresetBar" role="group" aria-label="UI Presets">
+                                    <button id="uiPresetClassic" type="button" class="button plannerPresetButton" onclick="view.setUiPreset('classic')"></button>
+                                    <button id="uiPresetPlanner" type="button" class="button plannerPresetButton" onclick="view.setUiPreset('planner')"></button>
+                                    <button id="uiPresetReader" type="button" class="button plannerPresetButton" onclick="view.setUiPreset('reader')"></button>
+                                    <button id="uiPresetCompact" type="button" class="button plannerPresetButton" onclick="view.setUiPreset('compact')"></button>
+                                </div>
+                                <button id="queueRepeatToggle" type="button" class="button plannerToggleButton" onclick="view.toggleQueueCompactRepeats()"></button>
+                            </div>
+                        </details>
+                    </div>
                 <div id="expandableList">
                     <div id="curActionsListContainer">
                         <div id="curActionsList"></div>
@@ -519,7 +508,6 @@
                                 <div id="loadoutManagerActions"></div>
                             </div>
                         </div>
-                        </div>
                         <div tabindex="0" class="showthatloadout"><span class="localized" data-lockey="actions>tooltip>manage_loadouts">管理预设</span>
                             <div class="showthisloadout">
                                 <button class="loadoutbutton unused" id="load1" onclick="selectLoadout(1)" style="width:200px">预设 1</button>
@@ -559,7 +547,8 @@
                                 <button class="loadoutbutton localized" style="margin-bottom:5px;margin-top:3px;margin-right:-4px;" onclick="nameList(true)" data-lockey="actions>tooltip>rename">重命名</button>
                             </div>
                         </div>
-                    </div>
+                        </div>
+                    </details>
                 </div>
             </div>
 

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -4147,10 +4147,6 @@ li#actionLogLatest {
 }
 
 #nextActionsAmountButtons {
-    position:absolute;
-    bottom:0;
-    left:0;
-    width:100%;
 }
 
 /* General scrollbar styling */
@@ -4740,7 +4736,7 @@ body.ui-density-large .chronicleStoryUnread {
         visibility: collapse;
     }
 
-    & #curActionsManaUsed, & #nextActionsAmountButtons {
+    & #curActionsManaUsed {
         position: static;
         width: auto;
         margin-top: auto;
@@ -4954,7 +4950,7 @@ body.ui-density-large .chronicleStoryUnread {
             visibility: collapse;
         }
     
-        & #curActionsManaUsed, & #nextActionsAmountButtons {
+        & #curActionsManaUsed {
             position: static;
             width: auto;
             margin-top: auto;
@@ -5293,7 +5289,7 @@ body.ui-density-large .chronicleStoryUnread {
             visibility: collapse;
         }
     
-        & #curActionsManaUsed, & #nextActionsAmountButtons {
+        & #curActionsManaUsed {
             position: static;
             width: auto;
             margin-top: auto;

--- a/views/timecontrols.view.js
+++ b/views/timecontrols.view.js
@@ -42,9 +42,9 @@ const timeControlsView = Views.registerView("timeControls", {
                 </div>
             </div>
         </div>
-        <details id='timeControlsOptionsCard'>
-            <summary id='timeControlsOptionsToggle'></summary>
-            <div id='timeControlsOptions'>
+        <details id='timeControlsOptionsCard' class='actionChangeCard actionChangeAccordion'>
+            <summary id='timeControlsOptionsToggle' class='actionChangeCardTitle actionChangeAccordionTitle'></summary>
+            <div id='timeControlsOptions' class='actionChangeAccordionBody'>
                 <div class='control'>
                     <input type='checkbox' id='pauseBeforeRestartInput' onchange='setOption("pauseBeforeRestart", this.checked)'>
                     <label for='pauseBeforeRestartInput'>${_txt("time_controls>pause_before_restart")}</label>


### PR DESCRIPTION
This PR addresses the current goals for the desktop UI refactor (`omsi-loops`):
- Converts advanced planner controls (Predictor, Presets) and time controls/pause rules into lightweight native `<details>` accordions in the secondary rail.
- Properly integrates `#nextActionsAmountButtons` into the main actions flow by removing CSS absolute positioning hacks and moving it outside the `<details>` wrappers.
- Fixes severe malformed HTML nesting introduced in a previous pass (dangling `</details>` and unbalanced `</div>`), restoring the stable structure of the layout panels.
- Retains compatibility with the standard 3-column layout requirements and keeps advanced controls out of the initial visual scan without hiding primary queues.

---
*PR created automatically by Jules for task [2287994093672034969](https://jules.google.com/task/2287994093672034969) started by @wenhuorongbing-netizen*