### PR TITLE
refactor(ui): slim down top nav and refactor town column layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,12 +68,12 @@
             </div>
             <details id="menuDeckDetails">
                 <summary>SAVES / OPTIONS / ADVANCED SYSTEMS</summary>
-            <div id="menuDeck">
-                <div id="menuDeckLabel"></div>
-                <menu id='menu' style='float: left; height: 30px; margin-left: 24px; margin-right: -24px;'></menu>
-            </div>
-        </div>
+                <div id="menuDeck">
+                    <div id="menuDeckLabel"></div>
+                    <menu id='menu'></menu>
+                </div>
             </details>
+        </div>
     </header>
 
     <main id="main">
@@ -575,15 +575,15 @@
 
         </div>
 
-        <div id="townColumn" style="width:535px;vertical-align:top;">
+        <div id="townColumn">
             <div id="shortTownColumn">
-                <div id="townWindow" style="width:100%;text-align:center;height:34px">
-                    <div style="float:left;margin-left:150px;" class="actionIcon fa fa-arrow-left" id="townViewLeft" onclick="view.showTown(townsUnlocked[townsUnlocked.indexOf(townShowing)-1])"></div>
+                <div id="townWindow">
+                    <div class="actionIcon fa fa-arrow-left" id="townViewLeft" onclick="view.showTown(townsUnlocked[townsUnlocked.indexOf(townShowing)-1])"></div>
                     <div class="showthat">
                         <div class="large bold"><select class="bold" style="text-align:center" id="TownSelect"></select></div>
                         <div id='townDesc' class='showthis'></div>
                     </div>
-                    <div style="float:right;margin-right:150px;" class="actionIcon fa fa-arrow-right" id="townViewRight" onclick="view.showTown(townsUnlocked[townsUnlocked.indexOf(townShowing)+1])"></div>
+                    <div class="actionIcon fa fa-arrow-right" id="townViewRight" onclick="view.showTown(townsUnlocked[townsUnlocked.indexOf(townShowing)+1])"></div>
                     <div id="hideVarsButton" class="far fa-eye" onclick="view.toggleHiding()"></div>
                 </div><br>
                 <div id="townInfos">
@@ -599,10 +599,10 @@
                 </div>
 
                 <div id="townActionTitle" class="block showthat" style="text-align:center;">
-                    <div style="float:left;margin-left:150px;" class="actionIcon fa fa-arrow-left" id="actionsViewLeft" onclick="view.showActions(false)"></div>
+                    <div class="actionIcon fa fa-arrow-left" id="actionsViewLeft" onclick="view.showActions(false)"></div>
                     <span class='large bold' id="actionsTitle"></span>
                     <div class='showthis localized' data-lockey="actions>tooltip>desc"></div>
-                    <div style="float:right;margin-right:150px;" class="actionIcon fa fa-arrow-right" id="actionsViewRight" onclick="view.showActions(true)"></div>
+                    <div class="actionIcon fa fa-arrow-right" id="actionsViewRight" onclick="view.showActions(true)"></div>
                 </div>
                 <div id="townActions">
                     <div id="actionOptionsTown0" class='actionOptions'></div>

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -116,7 +116,7 @@ body {
 #timeInfo {
     display: flex;
     justify-content: center;
-    padding: 12px 18px 14px;
+    padding: 8px 10px;
     background: linear-gradient(var(--body-background) 78%, var(--body-background-transparent) 100%);
     position: sticky;
     top: 0;
@@ -2015,16 +2015,17 @@ input[type="checkbox"][disabled] + label {
     border-bottom: 1px solid var(--zone-color);
     margin-bottom: 1ex;
     position: relative;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0 1rem;
 }
 
 #townActionTitle {
-    display: grid;
-    grid-template-columns: minmax(32px, max-content) minmax(0, 1fr) minmax(32px, max-content);
-    grid-template-areas:
-        "left title right"
-        "tools tools tools";
+    display: flex;
+    justify-content: space-between;
     align-items: center;
-    gap: 8px 10px;
+    text-align: center;
     background: color-mix(in srgb, var(--zone-color) 25%, var(--body-background));
     border-top: 1px solid var(--zone-color);
     border-bottom: 1px solid var(--zone-color);
@@ -2032,7 +2033,6 @@ input[type="checkbox"][disabled] + label {
     padding: 8px 10px 9px;
     width: 100%;
     box-sizing: border-box;
-    text-align: left;
 }
 
 #actionsViewLeft {
@@ -4571,7 +4571,7 @@ body.ui-density-large .chronicleStoryUnread {
             "resources menu" auto
             / minmax(0, 1.45fr) minmax(320px, 0.92fr);
         align-items: start;
-        gap: 10px 12px;
+        gap: 4px 8px;
     }
 
     & body > br, & #timeInfo > br {
@@ -4640,14 +4640,14 @@ body.ui-density-large .chronicleStoryUnread {
 
     & #townWindow {
         display: flex;
-        justify-content: center;
+        justify-content: space-between;
         align-items: center;
         flex-shrink: 0;
     }
 
     & #townActionTitle {
-        display: grid;
-        justify-content: stretch;
+        display: flex;
+        justify-content: space-between;
         align-items: center;
         flex-shrink: 0;
     }


### PR DESCRIPTION
- Fixed invalid closing `</div>` tag nesting for `menuDeckDetails` in `index.html`.
- Removed legacy inline floats (`float:left`, `float:right`) and hardcoded margins from town navigation arrows.
- Removed fixed inline width (`width:535px`) from `#townColumn` to let CSS manage sizing.
- Refactored `#townWindow` and `#townActionTitle` in `stylesheet.css` to utilize robust Flexbox (`justify-content: space-between`) instead of complex/brittle grid layouts and floats.
- Slimmed down `#timeInfo` and `#commandDeck` heights/paddings.
- Kept the UI in line with a unified 3-column desktop layout per EPIC-01, EPIC-03, and EPIC-06 constraints.

---
*PR created automatically by Jules for task [16697435141461300575](https://jules.google.com/task/16697435141461300575) started by @wenhuorongbing-netizen*