### PR TITLE
Remove blocking startup tutorial overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -638,10 +638,9 @@
         <a id="navbar_stats" href="#statsColumn" class="nav localized" data-lockey="menu>navigation>stats" onclick="return scrollToPanel(event, 'statsColumn')"></a>
     </nav>
 
-    <div id="tutorial" style="position:absolute;width:100%;height:100%;left:0;top:0;z-index:9999;">
-        <div style="width:100%;height:100%;background-color:grey;position:relative;opacity:.5"></div>
-        <div style="padding:20px;background-color:var(--body-background);border:1px solid var(--input-border);position:absolute;text-align:left;left:150px;top:150px;">
-            <span class="localized" data-lockey="tutorial"></span>
+    <div id="tutorial" style="position:fixed; bottom:20px; right:20px; z-index:9999; padding:20px; background-color:var(--body-background); border:1px solid var(--input-border); text-align:left; max-width:450px; box-shadow:0 4px 8px rgba(0,0,0,0.5); display:none;">
+        <span class="localized" data-lockey="tutorial"></span>
+        <div style="text-align: right; margin-top: 10px;">
             <button class="button localized" onclick="closeTutorial()" data-lockey="misc>ok">确定</button>
         </div>
     </div>

--- a/saving.js
+++ b/saving.js
@@ -1235,6 +1235,11 @@ function clearPauseNotification() {
 
 function closeTutorial() {
     document.getElementById("tutorial").style.display = "none";
+    window.localStorage.setItem("tutorialDismissed", "true");
+}
+
+function showTutorial() {
+    document.getElementById("tutorial").style.display = "block";
 }
 
 function clearSave() {
@@ -1284,8 +1289,13 @@ function load(inChallenge, saveJson = getSaveServiceApi().readSaveJson(window.lo
     let toLoad = {};
     // has a save file
     if (saveJson && saveJson !== "null") {
-        closeTutorial();
         toLoad = JSON.parse(saveJson);
+    }
+
+    if ((saveJson && saveJson !== "null") || window.localStorage.getItem("tutorialDismissed") === "true") {
+        document.getElementById("tutorial").style.display = "none";
+    } else {
+        document.getElementById("tutorial").style.display = "block";
     }
 
     console.log("Loading game from: " + saveName + " inChallenge: " + inChallenge);

--- a/views/menu.view.js
+++ b/views/menu.view.js
@@ -27,6 +27,7 @@ const menuView = Views.registerView("menu", {
                 simpleTooltips: "\u7b80\u5316\u63d0\u793a",
                 simpleTooltipsTooltip: "\u4e00\u952e\u964d\u4f4e hover \u63d0\u793a\u7684\u5bc6\u5ea6\uff0c\u5b8c\u6574\u6570\u503c\u4ecd\u4fdd\u7559\u5728 Inspector \u91cc\u3002",
                 viewHotkeys: "\u67e5\u770b\u952e\u4f4d",
+                showTutorial: "\u663e\u793a\u6559\u7a0b / \u63d0\u793a",
             }
             : {
                 quickSettingsTitle: "Quick Settings",

--- a/views/menu.view.js
+++ b/views/menu.view.js
@@ -34,6 +34,7 @@ const menuView = Views.registerView("menu", {
                 simpleTooltips: "Simple Tooltips",
                 simpleTooltipsTooltip: "Reduce hover tooltip density in one click. Full detail stays available in the Inspector.",
                 viewHotkeys: "View Hotkeys",
+                showTutorial: "Show Tutorial / Notice",
             };
         return texts[key] ?? key;
     },
@@ -177,6 +178,7 @@ const menuView = Views.registerView("menu", {
             ${_txt("menu>options>meta>title")}
             <div class='showthisH'>
                 <a target='_blank' href='${_txt("menu>options>discord>link")}'>${_txt("menu>options>discord>title")}</a><br>
+                <button class='button' onclick='showTutorial()'>${Views.menu.uiText('showTutorial')}</button><br>
                 ${Views.menu.htmlThemeMenu()}
                 ${Object.keys(Localization.supportedLang).length > 1 ? Views.menu.htmlLocalizationMenu() : ""}
                 ${_txt("menu>options>adblock_warning")}<br>


### PR DESCRIPTION
Fixes #12.

New sessions currently open with a blocking full-page tutorial overlay (`#tutorial`) that includes the host-specific greeting about starting the game somewhere other than `stopsign.github.io`. That overlay blocks the first interactive paint, covers the gameplay surface, and pollutes automated/manual screenshots.

This PR:
- Changes the tutorial popup container `div#tutorial` in `index.html` from a full-page modal (`position:absolute;width:100%;height:100%;left:0;top:0;`) to a floating notification window in the corner (`position:fixed; bottom:20px; right:20px; z-index:9999; padding:20px; box-shadow:0 4px 8px rgba(0,0,0,0.5); display:none;`).
- Adds a `localStorage` check to persist the tutorial dismissal status. In `saving.js`, `closeTutorial` sets `window.localStorage.setItem("tutorialDismissed", "true")`.
- In `saving.js`, modifies the `load` function to show the tutorial only if `tutorialDismissed` isn't `true` and the user does not have a valid loaded save.
- Provides a way to reopen the tutorial/warning in `views/menu.view.js`. Adds a "Show Tutorial / Notice" button in `htmlOptionsMenu` that calls `showTutorial()`. Adds translations for this button to `uiText`.

---
*PR created automatically by Jules for task [14621832016415656542](https://jules.google.com/task/14621832016415656542) started by @wenhuorongbing-netizen*