### PR TITLE
UI: Compact run/time control strip

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -158,13 +158,15 @@ body {
 }
 
 #runVitals {
-    padding: 6px 10px;
+    padding: 4px 8px;
 }
 
 .runVitalsLead {
-    display: grid;
-    gap: 0;
-    margin-bottom: 4px;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 6px;
+    margin-bottom: 2px;
 }
 
 .runVitalsEyebrow {
@@ -181,7 +183,7 @@ body {
 
 .runVitalsHeadline {
     font-family: Georgia, "Times New Roman", serif;
-    font-size: 1.2rem;
+    font-size: 1rem;
     font-weight: 700;
     line-height: 1.15;
 }
@@ -189,23 +191,23 @@ body {
 .runVitalsObjective {
     margin: 0;
     max-width: 62ch;
-    font-size: 0.94rem;
-    line-height: 1.45;
+    font-size: 0.85rem;
+    line-height: 1.3;
     opacity: 0.9;
 }
 
 .runVitalsGrid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(132px, 1fr));
-    gap: 4px;
+    grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
+    gap: 2px;
 }
 
 .runVitalCard {
     display: grid;
-    gap: 4px;
+    gap: 0px;
     min-height: auto;
     align-content: start;
-    padding: 4px 8px;
+    padding: 2px 6px;
     border: 1px solid color-mix(in srgb, var(--input-border) 74%, transparent);
     border-radius: 14px;
     background:
@@ -240,7 +242,7 @@ body {
 
 #timeControls {
     display: grid;
-    gap: 4px;
+    gap: 2px;
 }
 
 #timeControlsMain {
@@ -248,8 +250,8 @@ body {
     flex-wrap: wrap;
     align-items: center;
     justify-content: flex-start;
-    gap: 6px;
-    padding: 4px 8px;
+    gap: 4px;
+    padding: 2px 6px;
     border-radius: 16px;
     border: 1px solid color-mix(in srgb, var(--input-border) 76%, transparent);
     background:
@@ -262,8 +264,8 @@ body {
 }
 
 #timeControlsMain .button {
-    min-height: 30px;
-    padding: 0 14px;
+    min-height: 26px;
+    padding: 0 10px;
 }
 
 #timeControlsMain .button {
@@ -288,10 +290,10 @@ body {
     align-items: center;
     justify-content: space-between;
     gap: 10px;
-    padding: 4px 8px;
+    padding: 2px 6px;
     cursor: pointer;
     list-style: none;
-    font-size: 0.82rem;
+    font-size: 0.75rem;
     font-weight: 700;
 }
 
@@ -304,8 +306,8 @@ body {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 22px;
-    height: 22px;
+    width: 18px;
+    height: 18px;
     border-radius: 999px;
     background: color-mix(in srgb, var(--button-background) 18%, transparent);
     color: var(--button-background);
@@ -319,8 +321,8 @@ body {
 
 #timeControlsOptions {
     display: grid !important;
-    gap: 8px;
-    padding: 0 8px 8px;
+    gap: 4px;
+    padding: 0 6px 6px;
 }
 
 #timeControlsOptions .control {
@@ -4807,7 +4809,7 @@ body.ui-density-large .chronicleStoryUnread {
             display: flex;
             flex-wrap: nowrap;
             overflow-x: auto;
-            gap: 4px;
+            gap: 2px;
             max-height: none;
         }
 


### PR DESCRIPTION
This change tackles Task #41: Compacting the run/time control strip on the new-horizon baseline.

It tightly targets the `#runVitals` and `#timeControls` regions inside `stylesheet.css`. The updates reduce padding, container gaps, card minimum widths, and font sizes down to reasonable legibility floors. It changes the `.runVitalsLead` element from a grid block into a flex layout that can safely wrap text, freeing up significant vertical header space.

Changes:
* `#runVitals` and `.runVitalsGrid` paddings/gaps reduced.
* `#timeControlsMain` buttons have shorter minimum height.
* `.runVitalsLead` now uses flexbox for an inline-style flow.
* All relevant automated regression suites have been run and cleared.

---
*PR created automatically by Jules for task [16332738274955682864](https://jules.google.com/task/16332738274955682864) started by @wenhuorongbing-netizen*