### PR TITLE
Refactor top shell resource and menu decks for vertical compaction

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -172,6 +172,7 @@ body {
 }
 
 #menuDeckLabel {
+    display: none;
     font-size: 0.72rem;
     font-weight: 700;
     letter-spacing: 0.08em;
@@ -345,13 +346,15 @@ body {
 }
 
 #menuDeck {
-    display: grid;
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
     gap: 8px;
-    padding: 8px 14px 10px;
+    padding: 4px 10px;
 }
 
 #resourceDeck {
-    padding: 6px 14px 8px;
+    padding: 4px 10px;
 }
 
 #resourceDeck #trackedResources {


### PR DESCRIPTION
This PR addresses the task to compact the remaining `#resourceDeck` and `#menuDeck` in Classic.

Changes implemented:
- Modified `#menuDeckLabel` to use `display: none;` so that low-frequency text doesn't push the actual menu down.
- Refactored `#menuDeck` to use `display: flex; align-items: center; flex-wrap: wrap;` allowing items to reflow efficiently without taking up full grid rows.
- Reduced the vertical and horizontal paddings on both `#menuDeck` and `#resourceDeck`.

These changes push the main gameplay UI higher up into the initial viewport without hiding any core buttons. The work has been verified against 1280x720, 1024x768, and 390x844 responsive breakpoints using `npm run smoke` and `npm run fixtures:review`.

---
*PR created automatically by Jules for task [5471743848794831698](https://jules.google.com/task/5471743848794831698) started by @wenhuorongbing-netizen*