### PR TITLE
[Task]: Collapse run vitals into a compact first-screen status strip

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -161,14 +161,54 @@ body {
     padding: 6px 10px;
 }
 
-.runVitalsLead {
-    display: grid;
-    gap: 0;
-    margin-bottom: 4px;
+.runVitalsDetails {
+    /* Base wrapper for the native disclosure */
 }
 
-.runVitalsEyebrow {
-    display: none;
+.runVitalsSummary {
+    cursor: pointer;
+    list-style: none; /* Hide default arrow in standard browsers */
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 2px 0;
+    user-select: none;
+}
+
+.runVitalsSummary::-webkit-details-marker {
+    display: none; /* Hide arrow in Safari */
+}
+
+.runVitalsPrimary {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 6px 12px;
+}
+
+.runVitalsStatus {
+    font-weight: bold;
+    color: var(--text-color);
+}
+
+.runVitalTimer {
+    font-size: 1.1em;
+}
+
+.runVitalsAreaGroup {
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
+}
+
+.runVitalsArea {
+    font-weight: 600;
+}
+
+.runVitalsExpanded {
+    margin-top: 8px;
+    padding-top: 8px;
+    border-top: 1px solid color-mix(in srgb, var(--input-border) 40%, transparent);
 }
 
 #menuDeckLabel {
@@ -213,11 +253,6 @@ body {
         linear-gradient(180deg, color-mix(in srgb, var(--body-background) 90%, transparent), color-mix(in srgb, var(--popup-background) 54%, transparent));
 }
 
-.runVitalCard-primary {
-    background:
-        linear-gradient(135deg, color-mix(in srgb, var(--button-background) 16%, transparent), transparent 62%),
-        linear-gradient(180deg, color-mix(in srgb, var(--body-background) 92%, transparent), color-mix(in srgb, var(--popup-background) 58%, transparent));
-}
 
 .runVitalLabel {
     font-size: 0.65rem;
@@ -4814,10 +4849,6 @@ body.ui-density-large .chronicleStoryUnread {
             max-height: none;
         }
 
-        & .runVitalsLead {
-            display: none;
-        }
-
         & #menu {
             justify-content: flex-start;
             overflow-x: auto;
@@ -5052,10 +5083,6 @@ body.ui-density-large .chronicleStoryUnread {
             grid-template-columns: repeat(3, minmax(0, 1fr));
             max-height: 120px;
             overflow-y: auto;
-        }
-
-        & .runVitalsLead {
-            display: none;
         }
 
         & .runVitalCard {

--- a/views/main.view.js
+++ b/views/main.view.js
@@ -1014,37 +1014,43 @@ class View {
             ? `${progress.label} ${formatNumber(progress.level)}%`
             : (this.isChineseLanguage() ? "查看区域卡片获取进度" : "Open the area cards for live progress");
         container.innerHTML = `
-            <div class="runVitalsLead">
-                <div id="runStatusHeadline" class="runVitalsHeadline">${statusLabel}</div>
-                <p id="runObjectiveText" class="runVitalsObjective">${objectiveText}</p>
-            </div>
-            <div class="runVitalsGrid">
-                <div class="runVitalCard runVitalCard-primary">
-                    <span class="runVitalLabel">${this.isChineseLanguage() ? "剩余循环" : "Loop Remaining"}</span>
-                    <strong id="timer" class="runVitalValue">${intToString(remainingMana, options.fractionalMana ? 2 : 1, true)} | ${remainingTime}</strong>
-                    <span id="runLoopMeta" class="runVitalMeta">${this.isChineseLanguage() ? "第" : "Loop "}${currentLoopLabel}${this.isChineseLanguage() ? "轮" : ""}</span>
+            <details class="runVitalsDetails">
+                <summary class="runVitalsSummary">
+                    <div class="runVitalsPrimary">
+                        <span id="runStatusHeadline" class="runVitalsHeadline">${statusLabel}</span>
+                        <strong id="timer" class="runVitalValue runVitalTimer">${intToString(remainingMana, options.fractionalMana ? 2 : 1, true)} | ${remainingTime}</strong>
+                        <span id="runLoopMeta" class="runVitalMeta">${this.isChineseLanguage() ? "第" : "Loop "}${currentLoopLabel}${this.isChineseLanguage() ? "轮" : ""}</span>
+                        <span class="runVitalsAreaGroup">
+                            <span class="runVitalsDivider" aria-hidden="true">&bull;</span>
+                            <span id="runAreaName" class="runVitalsArea">${getTownName(townShowing)}</span>
+                        </span>
+                    </div>
+                </summary>
+                <div class="runVitalsExpanded">
+                    <p id="runObjectiveText" class="runVitalsObjective">${objectiveText}</p>
+                    <div class="runVitalsGrid">
+                        <div class="runVitalCard">
+                            <span class="runVitalLabel">${this.isChineseLanguage() ? "金币" : "Gold"}</span>
+                            <strong id="runGoldValue" class="runVitalValue">${formatNumber(resources.gold ?? 0)}</strong>
+                            <span class="runVitalMeta">${this.isChineseLanguage() ? "即时资源" : "Live resource"}</span>
+                        </div>
+                        <div class="runVitalCard">
+                            <span class="runVitalLabel">${this.isChineseLanguage() ? "进度" : "Progress"}</span>
+                            <strong id="runAreaProgress" class="runVitalValue">${progressText}</strong>
+                        </div>
+                        <div class="runVitalCard">
+                            <span class="runVitalLabel">${this.isChineseLanguage() ? "队列" : "Queue"}</span>
+                            <strong id="runQueueRowsValue" class="runVitalValue">${formatNumber(queueRows)}</strong>
+                            <span id="runQueueSummary" class="runVitalMeta">${this.isChineseLanguage() ? `${formatNumber(queueLoops)} 次可执行循环` : `${formatNumber(queueLoops)} executable loops queued`}</span>
+                        </div>
+                        <div class="runVitalCard">
+                            <span class="runVitalLabel">${this.isChineseLanguage() ? "新线索" : "Fresh Leads"}</span>
+                            <strong id="runLeadsValue" class="runVitalValue">${formatNumber(stats.unreadCount)}</strong>
+                            <span id="runLeadsSummary" class="runVitalMeta">${this.isChineseLanguage() ? `${formatNumber(stats.visibleCount)} 个已见行动` : `${formatNumber(stats.visibleCount)} visible actions`}</span>
+                        </div>
+                    </div>
                 </div>
-                <div class="runVitalCard">
-                    <span class="runVitalLabel">${this.isChineseLanguage() ? "金币" : "Gold"}</span>
-                    <strong id="runGoldValue" class="runVitalValue">${formatNumber(resources.gold ?? 0)}</strong>
-                    <span class="runVitalMeta">${this.isChineseLanguage() ? "即时资源" : "Live resource"}</span>
-                </div>
-                <div class="runVitalCard">
-                    <span class="runVitalLabel">${this.isChineseLanguage() ? "当前区域" : "Current Area"}</span>
-                    <strong id="runAreaName" class="runVitalValue">${getTownName(townShowing)}</strong>
-                    <span id="runAreaProgress" class="runVitalMeta">${progressText}</span>
-                </div>
-                <div class="runVitalCard">
-                    <span class="runVitalLabel">${this.isChineseLanguage() ? "队列" : "Queue"}</span>
-                    <strong id="runQueueRowsValue" class="runVitalValue">${formatNumber(queueRows)}</strong>
-                    <span id="runQueueSummary" class="runVitalMeta">${this.isChineseLanguage() ? `${formatNumber(queueLoops)} 次可执行循环` : `${formatNumber(queueLoops)} executable loops queued`}</span>
-                </div>
-                <div class="runVitalCard">
-                    <span class="runVitalLabel">${this.isChineseLanguage() ? "新线索" : "Fresh Leads"}</span>
-                    <strong id="runLeadsValue" class="runVitalValue">${formatNumber(stats.unreadCount)}</strong>
-                    <span id="runLeadsSummary" class="runVitalMeta">${this.isChineseLanguage() ? `${formatNumber(stats.visibleCount)} 个已见行动` : `${formatNumber(stats.visibleCount)} visible actions`}</span>
-                </div>
-            </div>
+            </details>
         `;
     }
 


### PR DESCRIPTION
Re-structures the `#runVitals` UI surface by wrapping it in a native `<details>` block. Essential state elements (timer, status, loop meta, and area) are moved to the `<summary>` so they remain permanently visible while dramatically reducing the vertical footprint. Lower-priority information (objective text, queue stats, lead count) is moved into the expanded section. Obsolete classes (`.runVitalsLead`, `.runVitalCard-primary`) have been removed. Tests ran perfectly and baselines have been checked.

---
*PR created automatically by Jules for task [18260066147682403959](https://jules.google.com/task/18260066147682403959) started by @wenhuorongbing-netizen*