### PR TITLE
Refactor runVitals to be a compact status strip

### DIFF
--- a/hotkeys.js
+++ b/hotkeys.js
@@ -66,7 +66,7 @@ class GameKeyboard {
 
 // Don't bind spacebar during button focus
 Mousetrap.prototype.stopCallback = (
-    (origStopCallback) => (e, element, combo) => (origStopCallback(e, element, combo) || (element.tagName === "BUTTON" && combo === "space"))
+    (origStopCallback) => (e, element, combo) => (origStopCallback(e, element, combo) || ((element.tagName === "BUTTON" || element.tagName === "SUMMARY") && combo === "space"))
 )(Mousetrap.prototype.stopCallback);
 
 GameKeyboard.spins = [];

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -158,13 +158,21 @@ body {
 }
 
 #runVitals {
-    padding: 6px 10px;
+    padding: 4px 8px;
 }
 
 .runVitalsLead {
-    display: grid;
-    gap: 0;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 8px;
     margin-bottom: 4px;
+}
+
+.runVitalsLeadText {
+    display: grid;
+    gap: 2px;
 }
 
 .runVitalsEyebrow {
@@ -182,7 +190,7 @@ body {
 
 .runVitalsHeadline {
     font-family: Georgia, "Times New Roman", serif;
-    font-size: 1.2rem;
+    font-size: 1.05rem;
     font-weight: 700;
     line-height: 1.15;
 }
@@ -190,23 +198,38 @@ body {
 .runVitalsObjective {
     margin: 0;
     max-width: 62ch;
-    font-size: 0.94rem;
+    font-size: 0.85rem;
     line-height: 1.45;
     opacity: 0.9;
 }
 
+.runVitalsDetails {
+    margin-top: 4px;
+}
+
+.runVitalsSummary {
+    cursor: pointer;
+    font-size: 0.75rem;
+    font-weight: bold;
+    color: var(--text-muted);
+    user-select: none;
+    margin-bottom: 4px;
+}
+
 .runVitalsGrid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(132px, 1fr));
+    display: flex;
+    flex-wrap: wrap;
     gap: 4px;
 }
 
 .runVitalCard {
+    flex: 1 1 auto;
+    min-width: 100px;
     display: grid;
     gap: 4px;
     min-height: auto;
     align-content: start;
-    padding: 4px 8px;
+    padding: 2px 6px;
     border: 1px solid color-mix(in srgb, var(--input-border) 74%, transparent);
     border-radius: 14px;
     background:
@@ -214,6 +237,12 @@ body {
 }
 
 .runVitalCard-primary {
+    display: flex;
+    flex-direction: row;
+    gap: 8px;
+    align-items: center;
+    padding: 4px 8px;
+    border-radius: 8px;
     background:
         linear-gradient(135deg, color-mix(in srgb, var(--button-background) 16%, transparent), transparent 62%),
         linear-gradient(180deg, color-mix(in srgb, var(--body-background) 92%, transparent), color-mix(in srgb, var(--popup-background) 58%, transparent));
@@ -4806,18 +4835,6 @@ body.ui-density-large .chronicleStoryUnread {
             gap: 4px;
         }
 
-        & .runVitalsGrid {
-            display: flex;
-            flex-wrap: nowrap;
-            overflow-x: auto;
-            gap: 4px;
-            max-height: none;
-        }
-
-        & .runVitalsLead {
-            display: none;
-        }
-
         & #menu {
             justify-content: flex-start;
             overflow-x: auto;
@@ -5048,20 +5065,7 @@ body.ui-density-large .chronicleStoryUnread {
             min-width: 0;
         }
 
-& .runVitalsGrid {
-            grid-template-columns: repeat(3, minmax(0, 1fr));
-            max-height: 120px;
-            overflow-y: auto;
-        }
-
-        & .runVitalsLead {
-            display: none;
-        }
-
         & .runVitalCard {
-            flex: 0 0 auto;
-            min-width: 90px;
-            min-height: 0;
             padding: 4px;
         }
 

--- a/views/main.view.js
+++ b/views/main.view.js
@@ -1013,38 +1013,46 @@ class View {
         const progressText = progress
             ? `${progress.label} ${formatNumber(progress.level)}%`
             : (this.isChineseLanguage() ? "查看区域卡片获取进度" : "Open the area cards for live progress");
+
+        const isDetailsOpen = document.getElementById("runVitalsDetails")?.hasAttribute("open") ? "open" : "";
+
         container.innerHTML = `
             <div class="runVitalsLead">
-                <div id="runStatusHeadline" class="runVitalsHeadline">${statusLabel}</div>
-                <p id="runObjectiveText" class="runVitalsObjective">${objectiveText}</p>
-            </div>
-            <div class="runVitalsGrid">
+                <div class="runVitalsLeadText">
+                    <div id="runStatusHeadline" class="runVitalsHeadline">${statusLabel}</div>
+                    <p id="runObjectiveText" class="runVitalsObjective">${objectiveText}</p>
+                </div>
                 <div class="runVitalCard runVitalCard-primary">
                     <span class="runVitalLabel">${this.isChineseLanguage() ? "剩余循环" : "Loop Remaining"}</span>
                     <strong id="timer" class="runVitalValue">${intToString(remainingMana, options.fractionalMana ? 2 : 1, true)} | ${remainingTime}</strong>
                     <span id="runLoopMeta" class="runVitalMeta">${this.isChineseLanguage() ? "第" : "Loop "}${currentLoopLabel}${this.isChineseLanguage() ? "轮" : ""}</span>
                 </div>
-                <div class="runVitalCard">
-                    <span class="runVitalLabel">${this.isChineseLanguage() ? "金币" : "Gold"}</span>
-                    <strong id="runGoldValue" class="runVitalValue">${formatNumber(resources.gold ?? 0)}</strong>
-                    <span class="runVitalMeta">${this.isChineseLanguage() ? "即时资源" : "Live resource"}</span>
-                </div>
-                <div class="runVitalCard">
-                    <span class="runVitalLabel">${this.isChineseLanguage() ? "当前区域" : "Current Area"}</span>
-                    <strong id="runAreaName" class="runVitalValue">${getTownName(townShowing)}</strong>
-                    <span id="runAreaProgress" class="runVitalMeta">${progressText}</span>
-                </div>
-                <div class="runVitalCard">
-                    <span class="runVitalLabel">${this.isChineseLanguage() ? "队列" : "Queue"}</span>
-                    <strong id="runQueueRowsValue" class="runVitalValue">${formatNumber(queueRows)}</strong>
-                    <span id="runQueueSummary" class="runVitalMeta">${this.isChineseLanguage() ? `${formatNumber(queueLoops)} 次可执行循环` : `${formatNumber(queueLoops)} executable loops queued`}</span>
-                </div>
-                <div class="runVitalCard">
-                    <span class="runVitalLabel">${this.isChineseLanguage() ? "新线索" : "Fresh Leads"}</span>
-                    <strong id="runLeadsValue" class="runVitalValue">${formatNumber(stats.unreadCount)}</strong>
-                    <span id="runLeadsSummary" class="runVitalMeta">${this.isChineseLanguage() ? `${formatNumber(stats.visibleCount)} 个已见行动` : `${formatNumber(stats.visibleCount)} visible actions`}</span>
-                </div>
             </div>
+            <details id="runVitalsDetails" class="runVitalsDetails" ${isDetailsOpen}>
+                <summary id="runVitalsSummary" class="runVitalsSummary">${this.isChineseLanguage() ? "更多状态" : "More Vitals"}</summary>
+                <div class="runVitalsGrid">
+                    <div class="runVitalCard">
+                        <span class="runVitalLabel">${this.isChineseLanguage() ? "金币" : "Gold"}</span>
+                        <strong id="runGoldValue" class="runVitalValue">${formatNumber(resources.gold ?? 0)}</strong>
+                        <span class="runVitalMeta">${this.isChineseLanguage() ? "即时资源" : "Live resource"}</span>
+                    </div>
+                    <div class="runVitalCard">
+                        <span class="runVitalLabel">${this.isChineseLanguage() ? "当前区域" : "Current Area"}</span>
+                        <strong id="runAreaName" class="runVitalValue">${getTownName(townShowing)}</strong>
+                        <span id="runAreaProgress" class="runVitalMeta">${progressText}</span>
+                    </div>
+                    <div class="runVitalCard">
+                        <span class="runVitalLabel">${this.isChineseLanguage() ? "队列" : "Queue"}</span>
+                        <strong id="runQueueRowsValue" class="runVitalValue">${formatNumber(queueRows)}</strong>
+                        <span id="runQueueSummary" class="runVitalMeta">${this.isChineseLanguage() ? `${formatNumber(queueLoops)} 次可执行循环` : `${formatNumber(queueLoops)} executable loops queued`}</span>
+                    </div>
+                    <div class="runVitalCard">
+                        <span class="runVitalLabel">${this.isChineseLanguage() ? "新线索" : "Fresh Leads"}</span>
+                        <strong id="runLeadsValue" class="runVitalValue">${formatNumber(stats.unreadCount)}</strong>
+                        <span id="runLeadsSummary" class="runVitalMeta">${this.isChineseLanguage() ? `${formatNumber(stats.visibleCount)} 个已见行动` : `${formatNumber(stats.visibleCount)} visible actions`}</span>
+                    </div>
+                </div>
+            </details>
         `;
     }
 


### PR DESCRIPTION
Fixes issue #59 by compacting the `#runVitals` section. Lower-priority stats are hidden by default within a `<details>` element, maintaining keyboard navigability. This significantly reduces the vertical footprint of the `#runVitals` dashboard allowing for more gameplay content to be shown in the first viewport.

---
*PR created automatically by Jules for task [1598438410501930673](https://jules.google.com/task/1598438410501930673) started by @wenhuorongbing-netizen*