### PR TITLE
Compact #runVitals into a summary strip and add viewport guardrails

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -158,7 +158,33 @@ body {
 }
 
 #runVitals {
+    padding: 0;
+}
+
+.runVitalsDetails {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+
+.runVitalsSummary {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(132px, 1fr));
+    gap: 4px;
     padding: 6px 10px;
+    cursor: pointer;
+    list-style: none;
+    align-items: stretch;
+}
+.runVitalsSummary::-webkit-details-marker {
+    display: none;
+}
+
+.runVitalsExpanded {
+    padding: 0 10px 10px 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
 }
 
 .runVitalsLead {
@@ -4814,6 +4840,13 @@ body.ui-density-large .chronicleStoryUnread {
             max-height: none;
         }
 
+        & .runVitalsSummary {
+            display: flex;
+            flex-wrap: nowrap;
+            overflow-x: auto;
+            gap: 4px;
+        }
+
         & .runVitalsLead {
             display: none;
         }
@@ -5051,6 +5084,11 @@ body.ui-density-large .chronicleStoryUnread {
 & .runVitalsGrid {
             grid-template-columns: repeat(3, minmax(0, 1fr));
             max-height: 120px;
+            overflow-y: auto;
+        }
+
+        & .runVitalsSummary {
+            grid-template-columns: repeat(3, minmax(0, 1fr));
             overflow-y: auto;
         }
 

--- a/tests/smoke/runtime-smoke.mjs
+++ b/tests/smoke/runtime-smoke.mjs
@@ -166,6 +166,12 @@ export async function runRuntimeSmoke({
         throw new Error(`Smoke failed to verify the accessibility shell contract. See ${resultsPath}`);
     }
     if (results.some(result =>
+        !result.viewport?.isActionsVisible1280
+        || !result.viewport?.isActionsVisible1024
+    )) {
+        throw new Error(`Smoke failed: primary action/town workspace is pushed below the first screen by the shell. See ${resultsPath}`);
+    }
+    if (results.some(result =>
         !result.saveBridge?.saveUsesAppContext
         || !result.saveBridge?.loadUsesAppContext
         || !result.saveBridge?.loadMatchesExpected
@@ -927,6 +933,28 @@ async function runLanguageScenario({baseUrl, browser, fixturePath, language, out
             }
         });
 
+        const viewportState = await page.evaluate(() => {
+            return {
+                isActionsVisible1280: true,
+                isActionsVisible1024: true,
+            };
+        });
+
+        // We run checks manually on viewport resizing, simulating the checks.
+        await page.setViewportSize({ width: 1280, height: 720 });
+        await page.waitForTimeout(500);
+        viewportState.isActionsVisible1280 = await page.evaluate(() => {
+            const el = document.getElementById("actionsColumn");
+            return el ? el.getBoundingClientRect().top < 720 : false;
+        });
+
+        await page.setViewportSize({ width: 1024, height: 768 });
+        await page.waitForTimeout(500);
+        viewportState.isActionsVisible1024 = await page.evaluate(() => {
+            const el = document.getElementById("actionsColumn");
+            return el ? el.getBoundingClientRect().top < 768 : false;
+        });
+
         const workerEvent = page.waitForEvent("worker", {timeout: 5000}).catch(() => null);
         const predictorStateBefore = await page.locator("#plannerPredictorState").textContent();
         await page.evaluate(() => {
@@ -955,6 +983,7 @@ async function runLanguageScenario({baseUrl, browser, fixturePath, language, out
             bootstrap: bootstrapState,
             compatBridge: compatBridgeState,
             accessibility: accessibilityState,
+            viewport: viewportState,
             saveBridge: saveBridgeState,
             queue: queueState,
             predictor: {

--- a/views/main.view.js
+++ b/views/main.view.js
@@ -1013,39 +1013,59 @@ class View {
         const progressText = progress
             ? `${progress.label} ${formatNumber(progress.level)}%`
             : (this.isChineseLanguage() ? "查看区域卡片获取进度" : "Open the area cards for live progress");
+        const detailsEl = document.getElementById("runVitalsDetails");
+        const wasOpen = detailsEl instanceof HTMLDetailsElement && detailsEl.open;
         container.innerHTML = `
-            <div class="runVitalsLead">
-                <div id="runStatusHeadline" class="runVitalsHeadline">${statusLabel}</div>
-                <p id="runObjectiveText" class="runVitalsObjective">${objectiveText}</p>
-            </div>
-            <div class="runVitalsGrid">
-                <div class="runVitalCard runVitalCard-primary">
-                    <span class="runVitalLabel">${this.isChineseLanguage() ? "剩余循环" : "Loop Remaining"}</span>
-                    <strong id="timer" class="runVitalValue">${intToString(remainingMana, options.fractionalMana ? 2 : 1, true)} | ${remainingTime}</strong>
-                    <span id="runLoopMeta" class="runVitalMeta">${this.isChineseLanguage() ? "第" : "Loop "}${currentLoopLabel}${this.isChineseLanguage() ? "轮" : ""}</span>
+            <details id="runVitalsDetails" class="runVitalsDetails" ${wasOpen ? "open" : ""}>
+                <summary class="runVitalsSummary">
+                    <div class="runVitalCard runVitalCard-primary">
+                        <span class="runVitalLabel">${this.isChineseLanguage() ? "剩余循环" : "Loop Remaining"}</span>
+                        <strong id="timer" class="runVitalValue">${intToString(remainingMana, options.fractionalMana ? 2 : 1, true)} | ${remainingTime}</strong>
+                        <span id="runLoopMeta" class="runVitalMeta">${this.isChineseLanguage() ? "第" : "Loop "}${currentLoopLabel}${this.isChineseLanguage() ? "轮" : ""}</span>
+                    </div>
+                    <div class="runVitalCard">
+                        <span class="runVitalLabel">${this.isChineseLanguage() ? "当前区域" : "Current Area"}</span>
+                        <strong id="runAreaName" class="runVitalValue">${getTownName(townShowing)}</strong>
+                        <span id="runAreaProgress" class="runVitalMeta">${progressText}</span>
+                    </div>
+                    <div class="runVitalCard">
+                        <span class="runVitalLabel">${this.isChineseLanguage() ? "状态" : "Status"}</span>
+                        <strong id="runStatusHeadline" class="runVitalValue">${statusLabel}</strong>
+                        <span class="runVitalMeta">${this.isChineseLanguage() ? "查看详情" : "See details"}</span>
+                    </div>
+                </summary>
+                <div class="runVitalsExpanded">
+                    <div class="runVitalsLead">
+                        <p id="runObjectiveText" class="runVitalsObjective">${objectiveText}</p>
+                    </div>
+                    <div class="runVitalsGrid">
+                        <div class="runVitalCard">
+                            <span class="runVitalLabel">${this.isChineseLanguage() ? "金币" : "Gold"}</span>
+                            <strong id="runGoldValue" class="runVitalValue">${formatNumber(resources.gold ?? 0)}</strong>
+                            <span class="runVitalMeta">${this.isChineseLanguage() ? "即时资源" : "Live resource"}</span>
+                        </div>
+                        <div class="runVitalCard">
+                            <span class="runVitalLabel">${this.isChineseLanguage() ? "队列" : "Queue"}</span>
+                            <strong id="runQueueRowsValue" class="runVitalValue">${formatNumber(queueRows)}</strong>
+                            <span id="runQueueSummary" class="runVitalMeta">${this.isChineseLanguage() ? `${formatNumber(queueLoops)} 次可执行循环` : `${formatNumber(queueLoops)} executable loops queued`}</span>
+                        </div>
+                        <div class="runVitalCard">
+                            <span class="runVitalLabel">${this.isChineseLanguage() ? "新线索" : "Fresh Leads"}</span>
+                            <strong id="runLeadsValue" class="runVitalValue">${formatNumber(stats.unreadCount)}</strong>
+                            <span id="runLeadsSummary" class="runVitalMeta">${this.isChineseLanguage() ? `${formatNumber(stats.visibleCount)} 个已见行动` : `${formatNumber(stats.visibleCount)} visible actions`}</span>
+                        </div>
+                    </div>
                 </div>
-                <div class="runVitalCard">
-                    <span class="runVitalLabel">${this.isChineseLanguage() ? "金币" : "Gold"}</span>
-                    <strong id="runGoldValue" class="runVitalValue">${formatNumber(resources.gold ?? 0)}</strong>
-                    <span class="runVitalMeta">${this.isChineseLanguage() ? "即时资源" : "Live resource"}</span>
-                </div>
-                <div class="runVitalCard">
-                    <span class="runVitalLabel">${this.isChineseLanguage() ? "当前区域" : "Current Area"}</span>
-                    <strong id="runAreaName" class="runVitalValue">${getTownName(townShowing)}</strong>
-                    <span id="runAreaProgress" class="runVitalMeta">${progressText}</span>
-                </div>
-                <div class="runVitalCard">
-                    <span class="runVitalLabel">${this.isChineseLanguage() ? "队列" : "Queue"}</span>
-                    <strong id="runQueueRowsValue" class="runVitalValue">${formatNumber(queueRows)}</strong>
-                    <span id="runQueueSummary" class="runVitalMeta">${this.isChineseLanguage() ? `${formatNumber(queueLoops)} 次可执行循环` : `${formatNumber(queueLoops)} executable loops queued`}</span>
-                </div>
-                <div class="runVitalCard">
-                    <span class="runVitalLabel">${this.isChineseLanguage() ? "新线索" : "Fresh Leads"}</span>
-                    <strong id="runLeadsValue" class="runVitalValue">${formatNumber(stats.unreadCount)}</strong>
-                    <span id="runLeadsSummary" class="runVitalMeta">${this.isChineseLanguage() ? `${formatNumber(stats.visibleCount)} 个已见行动` : `${formatNumber(stats.visibleCount)} visible actions`}</span>
-                </div>
-            </div>
+            </details>
         `;
+        const summaryEl = document.querySelector("#runVitalsDetails summary");
+        if (summaryEl) {
+            summaryEl.addEventListener("keydown", (e) => {
+                if (e.code === "Space") {
+                    e.stopPropagation();
+                }
+            });
+        }
     }
 
     updateRunVitalsLive() {

--- a/views/main.view.js
+++ b/views/main.view.js
@@ -999,6 +999,11 @@ class View {
     renderRunVitals() {
         const container = document.getElementById("runVitals");
         if (!(container instanceof HTMLElement)) return;
+        const detailsEl = document.getElementById("runVitalsDetails");
+        if (detailsEl instanceof HTMLDetailsElement) {
+            this.updateRunVitalsLive();
+            return;
+        }
         const stats = this.getTownBrowserStats();
         const progress = this.getPrimaryTownProgress();
         const remainingMana = Math.max(0, timeNeeded - timer);
@@ -1013,7 +1018,6 @@ class View {
         const progressText = progress
             ? `${progress.label} ${formatNumber(progress.level)}%`
             : (this.isChineseLanguage() ? "查看区域卡片获取进度" : "Open the area cards for live progress");
-        const detailsEl = document.getElementById("runVitalsDetails");
         const wasOpen = detailsEl instanceof HTMLDetailsElement && detailsEl.open;
         container.innerHTML = `
             <details id="runVitalsDetails" class="runVitalsDetails" ${wasOpen ? "open" : ""}>
@@ -1061,7 +1065,7 @@ class View {
         const summaryEl = document.querySelector("#runVitalsDetails summary");
         if (summaryEl) {
             summaryEl.addEventListener("keydown", (e) => {
-                if (e.code === "Space") {
+                if (e.code === "Space" || e.code === "Enter") {
                     e.stopPropagation();
                 }
             });
@@ -1070,7 +1074,8 @@ class View {
 
     updateRunVitalsLive() {
         const timerElement = document.getElementById("timer");
-        if (!(timerElement instanceof HTMLElement)) {
+        const detailsEl = document.getElementById("runVitalsDetails");
+        if (!(timerElement instanceof HTMLElement) || !(detailsEl instanceof HTMLDetailsElement)) {
             this.renderRunVitals();
             return;
         }


### PR DESCRIPTION
Addresses Issue #64 to isolate the highest-leverage source of first-screen height and compact the permanently expanded `#runVitals` presentation inside `#commandDeck`.

- The essential run metrics (Loop Remaining, Area, Status) have been compacted into an always-visible summary strip.
- Explanatory details and secondary stats (Gold, Queue, Fresh Leads, Objective text) are now tucked behind a native `<details>` inline disclosure, defaulting to closed.
- Keyboard accessibility was preserved by stopping `Space` propagation inside the `<summary>`, preventing the global pause/play from clashing with native disclosure expansions.
- The `updateRunVitalsLive` function works seamlessly with the new DOM hierarchy.
- Reusable smoke test assertions were added for `1280x720` and `1024x768` to ensure the action/town workspaces remain visible within the initial viewport bounds, ensuring regression coverage against future top-shell creep.

---
*PR created automatically by Jules for task [11220214327565168547](https://jules.google.com/task/11220214327565168547) started by @wenhuorongbing-netizen*