### PR TITLE
Collapse secondary top-shell chrome above the gameplay workspace

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,13 +63,14 @@
                 <div id="runVitals" aria-live="polite"></div>
                 <div id='timeControls'></div>
             </div>
-            <div id="resourceDeck">
+            <details id="resourceDeck">
+                <summary id="resourceDeckToggle">RESOURCES</summary>
                 <div id='trackedResources'></div>
-            </div>
-            <div id="menuDeck">
-                <div id="menuDeckLabel"></div>
+            </details>
+            <details id="menuDeck">
+                <summary id="menuDeckLabel"></summary>
                 <menu id='menu' style='float: left; height: 30px; margin-left: 24px; margin-right: -24px;'></menu>
-            </div>
+            </details>
         </div>
     </header>
 

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -285,11 +285,12 @@ body {
 }
 
 #timeControlsMain {
-    min-height: auto;
+    min-height: 0;
+    padding: 2px 4px;
 }
 
 #timeControlsMain .button {
-    min-height: 30px;
+    min-height: 26px;
     padding: 0 14px;
 }
 
@@ -385,6 +386,44 @@ body {
 
 #resourceDeck #trackedResources {
     justify-content: flex-start;
+}
+
+#resourceDeck > summary, #menuDeck > summary {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    padding: 8px 12px;
+    cursor: pointer;
+    user-select: none;
+    background-color: var(--button-background);
+    color: var(--button-text);
+    border-radius: 12px;
+    font-weight: 700;
+    text-transform: uppercase;
+    opacity: 0.72;
+}
+
+#resourceDeck > summary::-webkit-details-marker, #menuDeck > summary::-webkit-details-marker {
+    display: none;
+}
+
+#resourceDeck > summary::after, #menuDeck > summary::after {
+    content: "+";
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
+    border-radius: 50%;
+    background-color: var(--button-text);
+    color: var(--button-background);
+    font-size: 1rem;
+    line-height: 1;
+}
+
+#resourceDeck[open] > summary::after, #menuDeck[open] > summary::after {
+    content: "-";
 }
 
 #story_control {
@@ -5127,7 +5166,7 @@ body.ui-density-large .chronicleStoryUnread {
             width: auto;
             flex: 0 0 auto;
             justify-content: center;
-            min-height: 30px;
+            min-height: 26px;
             padding: 0 8px;
             font-size: 0.8rem;
         }

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -197,15 +197,6 @@ body {
     display: none;
 }
 
-#menuDeckLabel {
-    display: none;
-    font-size: 0.72rem;
-    font-weight: 700;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    opacity: 0.72;
-}
-
 .runVitalsHeadline {
     font-family: Georgia, "Times New Roman", serif;
     font-size: 1.2rem;
@@ -5180,10 +5171,6 @@ body.ui-density-large .chronicleStoryUnread {
 
         & #trackedResources > div {
             flex: 0 0 auto;
-        }
-
-        & #menuDeckLabel {
-            display: none;
         }
 
         & #menuDeck {

--- a/tests/smoke/runtime-smoke.mjs
+++ b/tests/smoke/runtime-smoke.mjs
@@ -168,6 +168,7 @@ export async function runRuntimeSmoke({
     if (results.some(result =>
         !result.viewport?.isActionsVisible1280
         || !result.viewport?.isActionsVisible1024
+        || !result.viewport?.isActionsVisible390
     )) {
         throw new Error(`Smoke failed: primary action/town workspace is pushed below the first screen by the shell. See ${resultsPath}`);
     }
@@ -937,6 +938,7 @@ async function runLanguageScenario({baseUrl, browser, fixturePath, language, out
             return {
                 isActionsVisible1280: true,
                 isActionsVisible1024: true,
+                isActionsVisible390: true,
             };
         });
 
@@ -953,6 +955,13 @@ async function runLanguageScenario({baseUrl, browser, fixturePath, language, out
         viewportState.isActionsVisible1024 = await page.evaluate(() => {
             const el = document.getElementById("actionsColumn");
             return el ? el.getBoundingClientRect().top < 768 : false;
+        });
+
+        await page.setViewportSize({ width: 390, height: 844 });
+        await page.waitForTimeout(500);
+        viewportState.isActionsVisible390 = await page.evaluate(() => {
+            const el = document.getElementById("actionsColumn");
+            return el ? el.getBoundingClientRect().top < 844 : false;
         });
 
         const workerEvent = page.waitForEvent("worker", {timeout: 5000}).catch(() => null);


### PR DESCRIPTION
This pull request resolves task #67 by compacting the default presentation of `#timeControls` and collapsing `#resourceDeck` and `#menuDeck` by default using native `<details>` elements. These changes are designed to ensure that the primary action/town workspace appears within the initial viewport on both desktop and mobile layouts. Additionally, the automated smoke tests were updated to enforce these vertical height assumptions across target viewports.

---
*PR created automatically by Jules for task [1045597994665903323](https://jules.google.com/task/1045597994665903323) started by @wenhuorongbing-netizen*