### PR TITLE
[Task] Tighten the always-visible command-deck frame above the gameplay workspace

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -116,7 +116,7 @@ body {
 #timeInfo {
     display: flex;
     justify-content: center;
-    padding: 6px 18px 8px;
+    padding: 2px 18px 4px;
     background: linear-gradient(var(--body-background) 78%, var(--body-background-transparent) 100%);
     position: sticky;
     top: 0;
@@ -125,7 +125,7 @@ body {
 
 #commandDeck {
     display: grid;
-    gap: 6px;
+    gap: 4px;
     width: min(100%, 1360px);
 }
 
@@ -140,7 +140,7 @@ body {
 #runStatusDeck {
     display: grid;
     grid-template-columns: minmax(0, 1.45fr) minmax(280px, 0.9fr);
-    gap: 6px;
+    gap: 4px;
     align-items: stretch;
 }
 
@@ -4620,7 +4620,7 @@ body.ui-density-large .chronicleStoryUnread {
             "resources menu" auto
             / minmax(0, 1.45fr) minmax(320px, 0.92fr);
         align-items: start;
-        gap: 10px 12px;
+        gap: 6px 12px;
     }
 
     & body > br, & #timeInfo > br {
@@ -4854,12 +4854,12 @@ body.ui-density-large .chronicleStoryUnread {
                 "resources" auto
                 "menu" auto
                 / 100%;
-            gap: 4px;
+            gap: 2px;
         }
 
         & #runStatusDeck {
             grid-template-columns: 1fr;
-            gap: 4px;
+            gap: 2px;
         }
 
         & .runVitalsGrid {
@@ -5088,7 +5088,7 @@ body.ui-density-large .chronicleStoryUnread {
 
         & #timeInfo {
             grid-area: header;
-            padding: 6px 6px 8px;
+            padding: 2px 6px 4px;
             min-width: 0;
             box-sizing: border-box;
         }
@@ -5100,14 +5100,14 @@ body.ui-density-large .chronicleStoryUnread {
                 "resources" auto
                 "menu" auto
                 / 100%;
-            gap: 6px;
+            gap: 4px;
             min-width: 0;
             box-sizing: border-box;
         }
 
         & #runStatusDeck {
             grid-template-columns: 1fr;
-            gap: 6px;
+            gap: 4px;
             min-width: 0;
         }
 


### PR DESCRIPTION
This PR reduces the default vertical footprint of the always-visible command-deck frame in the top shell.

**Changes:**
- Decreased vertical padding on `#timeInfo` to reduce top spacing.
- Decreased grid gaps in `#commandDeck` and `#runStatusDeck` from 6px to 4px in default viewports to tighten the elements.
- Scaled down the equivalent gaps/padding in the responsive media queries for smaller viewports (1280x720, 1024x768) and the mobile breakpoint (390x844).

**Validation:**
- Passed `npm run regression` and `npm run smoke`. 
- Viewport coordinate measurements verify that `commandDeckHeight` and `timeInfoHeight` are reduced across critical responsive breakpoints.
- Visual review confirmed that these changes pull the top edge of the primary actions and town workspace further up within the initial scroll view.

---
*PR created automatically by Jules for task [7321236418055073201](https://jules.google.com/task/7321236418055073201) started by @wenhuorongbing-netizen*