### PR TITLE
[Task]: Tighten the remaining #runStatusDeck shell above the gameplay workspace

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -141,10 +141,11 @@ body {
     display: grid;
     grid-template-columns: minmax(0, 1.45fr) minmax(280px, 0.9fr);
     gap: 4px;
-    align-items: stretch;
+    align-items: center;
+    padding: 2px 4px;
 }
 
-#runVitals,
+#runStatusDeck,
 #resourceDeck,
 #menuDeck {
     border: 1px solid color-mix(in srgb, var(--input-border) 76%, transparent);
@@ -171,7 +172,7 @@ body {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(132px, 1fr));
     gap: 4px;
-    padding: 6px 10px;
+    padding: 4px 6px;
     cursor: pointer;
     list-style: none;
     align-items: stretch;
@@ -267,12 +268,7 @@ body {
     align-items: center;
     justify-content: flex-start;
     gap: 4px;
-    padding: 2px 4px;
-    border-radius: 12px;
-    border: 1px solid color-mix(in srgb, var(--input-border) 76%, transparent);
-    background:
-        linear-gradient(180deg, color-mix(in srgb, var(--popup-background) 82%, transparent), color-mix(in srgb, var(--body-background) 82%, transparent));
-    box-shadow: inset 0 0 0 1px color-mix(in srgb, white 14%, transparent);
+    padding: 0;
     min-height: 0;
 }
 
@@ -5190,8 +5186,7 @@ body.ui-density-large .chronicleStoryUnread {
 
         & #menuDeck,
         & #resourceDeck,
-        & #runVitals,
-        & #timeControlsMain,
+        & #runStatusDeck,
         & #timeControlsOptionsCard {
             border-radius: 14px;
             padding: 2px 4px;


### PR DESCRIPTION
This PR addresses issue #76 by tightening the `#runStatusDeck` shell over the gameplay workspace. 

The persistent first-screen space cost was successfully reduced by shifting the visual boundaries (borders, background color, box-shadows) from the child layout items (`#runVitals` and `#timeControlsMain`) up to the parent wrapper (`#runStatusDeck`). 

By unifying the framing, we can safely eliminate the duplicated paddings/margins and the vertical inter-card gap between these critical controls. The summary strip (`#runVitals`) internal padding was additionally tightened to allow for a more cohesive strip look.

Visual testing on desktop (1280x720 and 1024x768) and mobile (390x844) viewports confirms the controls remain functionally accessible with preserved clickability while actively increasing the usable height for the primary town/action workspace below the shell. All existing automated smoke tests and regression checks continue to pass against the `new-horizon` baseline.

---
*PR created automatically by Jules for task [2221927913331468525](https://jules.google.com/task/2221927913331468525) started by @wenhuorongbing-netizen*