### PR TITLE
Collapse action-pane stack above default town cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -580,7 +580,7 @@
                     </div>
                     <div style="float:right;margin-right:150px;" class="actionIcon fa fa-arrow-right" id="townViewRight" onclick="view.showTown(townsUnlocked[townsUnlocked.indexOf(townShowing)+1])"></div>
                     <div id="hideVarsButton" class="far fa-eye" onclick="view.toggleHiding()"></div>
-                </div><br>
+                </div>
                 <div id="townInfos">
                     <div id="townInfo0" class='townInfo'></div>
                     <div id="townInfo1" class='townInfo' style="display:none;"></div>

--- a/index.html
+++ b/index.html
@@ -572,7 +572,7 @@
 
         <div id="townColumn" style="width:535px;vertical-align:top;">
             <div id="shortTownColumn">
-                <div id="townWindow" style="width:100%;text-align:center;height:34px">
+                <div id="townWindow" style="width:100%;text-align:center;height:24px">
                     <div style="float:left;margin-left:150px;" class="actionIcon fa fa-arrow-left" id="townViewLeft" onclick="view.showTown(townsUnlocked[townsUnlocked.indexOf(townShowing)-1])"></div>
                     <div class="showthat">
                         <div class="large bold"><select class="bold" style="text-align:center" id="TownSelect"></select></div>

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -2483,9 +2483,9 @@ input[type="checkbox"][disabled] + label {
     display:grid;
     text-align:left;
     grid-template-columns: [full-row-start] repeat(2, max-content) [progress-value-start] repeat(2, max-content) [progress-value-end] repeat(2, max-content) [progress-bars-start] repeat(2, max-content) 1fr [progress-bars-end full-row-end];
-    grid-auto-rows: minmax(32px,1fr);
+    grid-auto-rows: minmax(24px,1fr);
     align-items: center;
-    gap: 4px;
+    gap: 2px;
 }
 
 .townContainer {
@@ -4681,6 +4681,7 @@ body.ui-density-large .chronicleStoryUnread {
         justify-content: center;
         align-items: center;
         flex-shrink: 0;
+        margin-bottom: 0;
     }
 
     & #townActionTitle {
@@ -4688,6 +4689,7 @@ body.ui-density-large .chronicleStoryUnread {
         justify-content: stretch;
         align-items: center;
         flex-shrink: 0;
+        margin: 0;
     }
 
     & #townViewLeft, #townViewRight, #actionsViewLeft, & #actionsViewRight {
@@ -4945,6 +4947,7 @@ body.ui-density-large .chronicleStoryUnread {
         }
         
         & #townWindow {
+            margin-bottom: 0;
         }
     
         & #townWindow > div.showthat {
@@ -5349,6 +5352,7 @@ body.ui-density-large .chronicleStoryUnread {
             justify-content: center;
             align-items: center;
             flex-shrink: 0;
+            margin-bottom: 0;
         }
     
         & #townWindow > div.showthat {

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -2051,7 +2051,7 @@ input[type="checkbox"][disabled] + label {
     --default-background: color-mix(in srgb, var(--zone-color) 50%, var(--next-actions-background));
     background: var(--default-background);
     border-bottom: 1px solid var(--zone-color);
-    margin-bottom: 1ex;
+    margin-bottom: 0.5ex;
     position: relative;
 }
 
@@ -2066,8 +2066,8 @@ input[type="checkbox"][disabled] + label {
     background: color-mix(in srgb, var(--zone-color) 25%, var(--body-background));
     border-top: 1px solid var(--zone-color);
     border-bottom: 1px solid var(--zone-color);
-    margin: 1.1ex 0 0.7ex;
-    padding: 8px 10px 9px;
+    margin: 0.5ex 0 0.5ex;
+    padding: 4px 10px;
     width: 100%;
     box-sizing: border-box;
     text-align: left;


### PR DESCRIPTION
This PR addresses issue #81 by tightening the vertical space consumed by the always-visible action-pane stack above the default town action cards in the Classic preset.

Changes:
* Removed the `<br>` element following `#townWindow` in `index.html`.
* Reduced the `margin-bottom` of `#townWindow` to `0.5ex` in `stylesheet.css`.
* Reduced the `margin` of `#townActionTitle` to `0.5ex 0 0.5ex` in `stylesheet.css`.
* Reduced the `padding` of `#townActionTitle` to `4px 10px` in `stylesheet.css`.

These changes successfully collapse the excessive white space above the grid without modifying the queue row, the top shell, or the action cards themselves. The layout was verified with Playwright smoke tests to confirm that the default town cards are now visible on the first screen at `1280x720`, `1024x768`, and `390x844` without scrolling. All tests (`npm run smoke` and `npm run regression`) continue to pass.

---
*PR created automatically by Jules for task [8335888287790480696](https://jules.google.com/task/8335888287790480696) started by @wenhuorongbing-netizen*