### PR TITLE
[Task]: Make Classic desktop and laptop layout use a compact gameplay shell

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -5551,3 +5551,57 @@ select.bold {
 select.bold:focus {
     border-color: var(--town-select-focus-border);
 }
+
+@media (min-width: 811px) and (max-width: 1300px) {
+    :root.responsive:has(body.ui-preset-classic) {
+        height: 100%;
+        overflow: clip;
+        contain: strict;
+    }
+
+    .responsive body.ui-preset-classic {
+        min-width: 0 !important;
+        overflow: hidden !important;
+        height: 100vh;
+        grid:
+            "header header header" max-content
+            "actions town stats" minmax(0, 1fr)
+            / minmax(280px, 1.08fr) minmax(400px, 1.58fr) minmax(280px, 1.16fr) !important;
+    }
+
+    .responsive body.ui-preset-classic main {
+        display: contents;
+    }
+
+    .responsive body.ui-preset-classic #timeInfo {
+        grid-area: header;
+        display: flex;
+    }
+
+    .responsive body.ui-preset-classic #actionsColumn {
+        grid-area: actions;
+        margin: 0;
+    }
+
+    .responsive body.ui-preset-classic #townColumn {
+        display: flex;
+        grid-area: town;
+    }
+
+    .responsive body.ui-preset-classic #shortTownColumn {
+        display: none;
+    }
+
+    .responsive body.ui-preset-classic #statsColumn {
+        grid-area: stats;
+    }
+
+    .responsive body.ui-preset-classic #actionLogContainer {
+        display: none;
+    }
+}
+
+.responsive body.ui-preset-classic #timeInfo {
+    box-sizing: border-box;
+    width: 100%;
+}

--- a/tests/smoke/runtime-smoke.mjs
+++ b/tests/smoke/runtime-smoke.mjs
@@ -939,6 +939,10 @@ async function runLanguageScenario({baseUrl, browser, fixturePath, language, out
                 isActionsVisible1280: true,
                 isActionsVisible1024: true,
                 isActionsVisible390: true,
+                isActionsVisible1280Classic: true,
+                hasOverflow1280Classic: false,
+                isActionsVisible1024Classic: true,
+                hasOverflow1024Classic: false,
             };
         });
 
@@ -962,6 +966,40 @@ async function runLanguageScenario({baseUrl, browser, fixturePath, language, out
         viewportState.isActionsVisible390 = await page.evaluate(() => {
             const el = document.getElementById("actionsColumn");
             return el ? el.getBoundingClientRect().top < 844 : false;
+        });
+
+        // Classic preset metrics
+        await page.evaluate(() => {
+            const presetBtn = document.getElementById("uiPresetClassic");
+            if (presetBtn) presetBtn.click();
+        });
+
+        await page.setViewportSize({ width: 1280, height: 720 });
+        await page.waitForTimeout(500);
+        const classic1280Metrics = await page.evaluate(() => {
+            const el = document.getElementById("actionsColumn");
+            const isVisible = el ? el.getBoundingClientRect().top < 720 : false;
+            const overflow = document.documentElement.scrollWidth > 1280 || document.body.scrollWidth > 1280;
+            return { isVisible, overflow };
+        });
+        viewportState.isActionsVisible1280Classic = classic1280Metrics.isVisible;
+        viewportState.hasOverflow1280Classic = classic1280Metrics.overflow;
+
+        await page.setViewportSize({ width: 1024, height: 768 });
+        await page.waitForTimeout(500);
+        const classic1024Metrics = await page.evaluate(() => {
+            const el = document.getElementById("actionsColumn");
+            const isVisible = el ? el.getBoundingClientRect().top < 768 : false;
+            const overflow = document.documentElement.scrollWidth > 1024 || document.body.scrollWidth > 1024;
+            return { isVisible, overflow };
+        });
+        viewportState.isActionsVisible1024Classic = classic1024Metrics.isVisible;
+        viewportState.hasOverflow1024Classic = classic1024Metrics.overflow;
+
+        // Revert preset
+        await page.evaluate(() => {
+            const presetBtn = document.getElementById("uiPresetCompact");
+            if (presetBtn) presetBtn.click();
         });
 
         const workerEvent = page.waitForEvent("worker", {timeout: 5000}).catch(() => null);

--- a/tests/smoke/runtime-smoke.mjs
+++ b/tests/smoke/runtime-smoke.mjs
@@ -169,10 +169,10 @@ export async function runRuntimeSmoke({
         !result.viewport?.isActionsVisible1280
         || !result.viewport?.isActionsVisible1024
         || !result.viewport?.isActionsVisible390
-        || !result.viewport?.isActionsVisible1280Classic
-        || result.viewport?.hasOverflow1280Classic
-        || !result.viewport?.isActionsVisible1024Classic
-        || result.viewport?.hasOverflow1024Classic
+        || !result.viewport?.classic1280?.isActionsVisible
+        || result.viewport?.classic1280?.hasOverflow
+        || !result.viewport?.classic1024?.isActionsVisible
+        || result.viewport?.classic1024?.hasOverflow
     )) {
         throw new Error(`Smoke failed: primary action/town workspace is pushed below the first screen by the shell or horizontal overflow detected. See ${resultsPath}`);
     }
@@ -943,10 +943,8 @@ async function runLanguageScenario({baseUrl, browser, fixturePath, language, out
                 isActionsVisible1280: true,
                 isActionsVisible1024: true,
                 isActionsVisible390: true,
-                isActionsVisible1280Classic: true,
-                hasOverflow1280Classic: false,
-                isActionsVisible1024Classic: true,
-                hasOverflow1024Classic: false,
+                classic1280: null,
+                classic1024: null,
             };
         });
 
@@ -980,25 +978,49 @@ async function runLanguageScenario({baseUrl, browser, fixturePath, language, out
 
         await page.setViewportSize({ width: 1280, height: 720 });
         await page.waitForTimeout(500);
-        const classic1280Metrics = await page.evaluate(() => {
-            const el = document.getElementById("actionsColumn");
-            const isVisible = el ? el.getBoundingClientRect().top < 720 : false;
+        viewportState.classic1280 = await page.evaluate(() => {
+            const actions = document.getElementById("actionsColumn");
+            const town = document.getElementById("townColumn");
+            const stats = document.getElementById("statsColumn");
+
+            const isVisible = actions ? actions.getBoundingClientRect().top < 720 : false;
             const overflow = document.documentElement.scrollWidth > 1280 || document.body.scrollWidth > 1280;
-            return { isVisible, overflow };
+
+            return {
+                viewport: { width: 1280, height: 720 },
+                bodyClass: document.body.className,
+                rootClass: document.documentElement.className,
+                scrollWidth: Math.max(document.documentElement.scrollWidth, document.body.scrollWidth),
+                actionsColumn: actions ? actions.getBoundingClientRect() : null,
+                townColumn: town ? town.getBoundingClientRect() : null,
+                statsColumn: stats ? stats.getBoundingClientRect() : null,
+                isActionsVisible: isVisible,
+                hasOverflow: overflow,
+            };
         });
-        viewportState.isActionsVisible1280Classic = classic1280Metrics.isVisible;
-        viewportState.hasOverflow1280Classic = classic1280Metrics.overflow;
 
         await page.setViewportSize({ width: 1024, height: 768 });
         await page.waitForTimeout(500);
-        const classic1024Metrics = await page.evaluate(() => {
-            const el = document.getElementById("actionsColumn");
-            const isVisible = el ? el.getBoundingClientRect().top < 768 : false;
+        viewportState.classic1024 = await page.evaluate(() => {
+            const actions = document.getElementById("actionsColumn");
+            const town = document.getElementById("townColumn");
+            const stats = document.getElementById("statsColumn");
+
+            const isVisible = actions ? actions.getBoundingClientRect().top < 768 : false;
             const overflow = document.documentElement.scrollWidth > 1024 || document.body.scrollWidth > 1024;
-            return { isVisible, overflow };
+
+            return {
+                viewport: { width: 1024, height: 768 },
+                bodyClass: document.body.className,
+                rootClass: document.documentElement.className,
+                scrollWidth: Math.max(document.documentElement.scrollWidth, document.body.scrollWidth),
+                actionsColumn: actions ? actions.getBoundingClientRect() : null,
+                townColumn: town ? town.getBoundingClientRect() : null,
+                statsColumn: stats ? stats.getBoundingClientRect() : null,
+                isActionsVisible: isVisible,
+                hasOverflow: overflow,
+            };
         });
-        viewportState.isActionsVisible1024Classic = classic1024Metrics.isVisible;
-        viewportState.hasOverflow1024Classic = classic1024Metrics.overflow;
 
         // Revert preset
         await page.evaluate(() => {

--- a/tests/smoke/runtime-smoke.mjs
+++ b/tests/smoke/runtime-smoke.mjs
@@ -169,8 +169,12 @@ export async function runRuntimeSmoke({
         !result.viewport?.isActionsVisible1280
         || !result.viewport?.isActionsVisible1024
         || !result.viewport?.isActionsVisible390
+        || !result.viewport?.isActionsVisible1280Classic
+        || result.viewport?.hasOverflow1280Classic
+        || !result.viewport?.isActionsVisible1024Classic
+        || result.viewport?.hasOverflow1024Classic
     )) {
-        throw new Error(`Smoke failed: primary action/town workspace is pushed below the first screen by the shell. See ${resultsPath}`);
+        throw new Error(`Smoke failed: primary action/town workspace is pushed below the first screen by the shell or horizontal overflow detected. See ${resultsPath}`);
     }
     if (results.some(result =>
         !result.saveBridge?.saveUsesAppContext


### PR DESCRIPTION
Implemented responsive layout contract specifically for the `Classic` preset at mid-size breakpoints (such as 1280x720 and 1024x768). Previously, the `Classic` layout fell back to a two-column 2x2 grid layout which pushed actions, stats, or logs off-screen. This change restores the three-column compact gameplay shell. Added automated Playwright/runtime metrics to `tests/smoke/runtime-smoke.mjs` to specifically check for visibility and horizontal overflow on the `Classic` layout at standard screen dimensions.

---
*PR created automatically by Jules for task [6263517496589422458](https://jules.google.com/task/6263517496589422458) started by @wenhuorongbing-netizen*