### PR TITLE
style: compact top shell UI footprint

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -116,7 +116,7 @@ body {
 #timeInfo {
     display: flex;
     justify-content: center;
-    padding: 2px 18px 4px;
+    padding: 2px 10px 4px;
     background: linear-gradient(var(--body-background) 78%, var(--body-background-transparent) 100%);
     position: sticky;
     top: 0;
@@ -125,13 +125,13 @@ body {
 
 #commandDeck {
     display: grid;
-    gap: 4px;
+    gap: 2px;
     width: min(100%, 1360px);
 }
 
 #timeBarContainer {
     width: 100% !important;
-    height: 14px !important;
+    height: 10px !important;
     border-radius: 999px;
     overflow: hidden;
     box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--input-border) 65%, transparent);
@@ -140,7 +140,7 @@ body {
 #runStatusDeck {
     display: grid;
     grid-template-columns: minmax(0, 1.45fr) minmax(280px, 0.9fr);
-    gap: 4px;
+    gap: 2px;
     align-items: center;
     padding: 2px 4px;
 }
@@ -149,7 +149,7 @@ body {
 #resourceDeck,
 #menuDeck {
     border: 1px solid color-mix(in srgb, var(--input-border) 76%, transparent);
-    border-radius: 18px;
+    border-radius: 12px;
     background:
         linear-gradient(180deg, color-mix(in srgb, var(--popup-background) 84%, transparent), color-mix(in srgb, var(--body-background) 82%, transparent)),
         radial-gradient(circle at top left, color-mix(in srgb, var(--zone-color) 10%, transparent), transparent 44%);
@@ -171,8 +171,8 @@ body {
 .runVitalsSummary {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(132px, 1fr));
-    gap: 4px;
-    padding: 4px 6px;
+    gap: 2px;
+    padding: 2px 4px;
     cursor: pointer;
     list-style: none;
     align-items: stretch;
@@ -182,7 +182,7 @@ body {
 }
 
 .runVitalsExpanded {
-    padding: 0 10px 10px 10px;
+    padding: 0 4px 4px 4px;
     display: flex;
     flex-direction: column;
     gap: 6px;
@@ -224,9 +224,9 @@ body {
     gap: 4px;
     min-height: auto;
     align-content: start;
-    padding: 4px 8px;
+    padding: 2px 4px;
     border: 1px solid color-mix(in srgb, var(--input-border) 74%, transparent);
-    border-radius: 14px;
+    border-radius: 8px;
     background:
         linear-gradient(180deg, color-mix(in srgb, var(--body-background) 90%, transparent), color-mix(in srgb, var(--popup-background) 54%, transparent));
 }
@@ -373,7 +373,7 @@ body {
     align-items: center;
     justify-content: space-between;
     gap: 10px;
-    padding: 8px 12px;
+    padding: 4px 8px;
     cursor: pointer;
     user-select: none;
     background-color: var(--button-background);
@@ -4840,7 +4840,7 @@ body.ui-density-large .chronicleStoryUnread {
 
         & #commandDeck {
             grid:
-                "time" 14px
+                "time" 10px
                 "run" auto
                 "resources" auto
                 "menu" auto
@@ -5080,19 +5080,19 @@ body.ui-density-large .chronicleStoryUnread {
 
         & #timeInfo {
             grid-area: header;
-            padding: 2px 6px 4px;
+            padding: 1px 4px 2px;
             min-width: 0;
             box-sizing: border-box;
         }
 
         & #commandDeck {
             grid:
-                "time" 12px
+                "time" 8px
                 "run" auto
                 "resources" auto
                 "menu" auto
                 / 100%;
-            gap: 4px;
+            gap: 2px;
             min-width: 0;
             box-sizing: border-box;
         }
@@ -5122,7 +5122,7 @@ body.ui-density-large .chronicleStoryUnread {
             flex: 0 0 auto;
             min-width: 90px;
             min-height: 0;
-            padding: 4px;
+            padding: 2px;
         }
 
         & .runVitalLabel {


### PR DESCRIPTION
#94 [Task]: Compact the top shell so gameplay is reachable from the first viewport

This PR compacts the top shell to make the primary gameplay workspace visible and usable from the first viewport, satisfying issue #94.

- Reduced vertical space, grid gaps, margins, and card paddings across top shell headers (`#commandDeck`, `#runStatusDeck`, `.runVitalCard`, `.runVitalsExpanded`, etc.).
- Compacted `#resourceDeck` and `#menuDeck` summaries.
- Scaled down padding, gaps, and heights proportionately in responsive media queries (`@media (max-width: 1300px)` and `810px`) so mobile environments similarly benefit without losing layout structure or overlapping.
- Tested and verified fresh layouts via local server (Playwright testing) against standard viewport resolutions (`1280x720`, `1024x768`, and `390x844`), ensuring gameplay begins immediately beneath the top shell chrome.

All smoke, regression, and fixture review tests pass successfully.

---
*PR created automatically by Jules for task [9317597090116987376](https://jules.google.com/task/9317597090116987376) started by @wenhuorongbing-netizen*