### PR TITLE
Stabilize desktop and tablet town browser/action log visibility

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -5585,11 +5585,18 @@ select.bold:focus {
 
     .responsive body.ui-preset-classic #townColumn {
         display: flex;
+        flex-direction: column;
         grid-area: town;
+        overflow: hidden;
+        gap: 10px;
     }
 
     .responsive body.ui-preset-classic #shortTownColumn {
-        display: none;
+        display: flex;
+        flex-direction: column;
+        flex: 1 1 auto;
+        min-height: 0;
+        overflow: hidden;
     }
 
     .responsive body.ui-preset-classic #statsColumn {
@@ -5597,7 +5604,11 @@ select.bold:focus {
     }
 
     .responsive body.ui-preset-classic #actionLogContainer {
-        display: none;
+        display: flex;
+        flex-direction: column;
+        flex: 0 0 auto;
+        height: 25%;
+        min-height: 100px;
     }
 }
 

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -5596,7 +5596,7 @@ select.bold:focus {
         flex-direction: column;
         flex: 1 1 auto;
         min-height: 0;
-        overflow: hidden;
+        overflow-y: auto;
     }
 
     .responsive body.ui-preset-classic #statsColumn {


### PR DESCRIPTION
This PR addresses issue #95 by stabilizing the desktop and tablet layout for the secondary right-hand town browser panel.

Previously, `stylesheet.css` explicitly applied `display: none` to the `#shortTownColumn` and `#actionLogContainer` elements for screen widths between 811px and 1300px, causing them to disappear entirely from view.

**Changes:**
- Removed `display: none` for `#shortTownColumn` and `#actionLogContainer` in the `@media (min-width: 811px) and (max-width: 1300px)` media block.
- Applied `display: flex` and `flex-direction: column` to the main `#townColumn` and assigned it `gap: 10px;` and `overflow: hidden;`.
- Allowed the primary town content (`#shortTownColumn`) to take up remaining vertical space smoothly using `flex: 1 1 auto; min-height: 0; overflow: hidden;`.
- Set `#actionLogContainer` to share the stack with a stable presence, pinning it below the main controls using `height: 25%; min-height: 100px; flex: 0 0 auto;`.

**Validation:**
- Passed visually verified Playwright UI checks on 1280x720 (Desktop) and 1024x768 (Tablet/Narrow) viewports.
- All elements rendered securely in the designated right-hand side, retaining stable footprints without relying on legacy numeric assumptions or full mobile redesign scope.
- Executed and passed `npm run smoke`, `npm run regression`, and `npm run fixtures:review`.

---
*PR created automatically by Jules for task [3165982453604489702](https://jules.google.com/task/3165982453604489702) started by @wenhuorongbing-netizen*