### PR TITLE
Stabilize desktop and tablet town browser/action log visibility

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -571,7 +571,7 @@ input, select, textarea {
 }
 
 /* These are only used in mobile view  */
-main, #actionLogContainer {
+main {
     display: contents;
 }
 #navbar {
@@ -4641,6 +4641,11 @@ body.ui-density-large .chronicleStoryUnread {
         display: flex;
     }
 
+    & #actionLogContainer {
+        display: flex;
+        flex-direction: column;
+    }
+
     & #statsColumn {
     grid-area: stats;  
     }  
@@ -4889,8 +4894,8 @@ body.ui-density-large .chronicleStoryUnread {
             display: grid;
             height: 100%;
             grid:
-                "actions town" minmax(600px, max-content)
-                "stats log"
+                "actions town" auto
+                "stats log" minmax(0, 1fr)
                 / minmax(min-content,3fr) minmax(min-content,2fr);
             margin-right:0.5em;
         }
@@ -4900,7 +4905,10 @@ body.ui-density-large .chronicleStoryUnread {
         }
 
         & #statsColumn, & #actionsColumn, & #shortTownColumn, & #actionLogContainer {
-            overflow: initial;
+            overflow-x: hidden;
+            overflow-y: auto;
+            flex-direction: column;
+            display: flex;
         }
 
         & #statsWindow {


### PR DESCRIPTION
This PR fixes Issue #95 by stabilizing the visibility of the right-side secondary pane (containing the town browser and action log) in the Desktop and Tablet viewports.

Changes made:
- Prevented `#actionLogContainer` from bleeding its contents directly into parent flex axes by replacing the global `display: contents` override.
- Integrated `#actionLogContainer` into the standard viewport rules (`.responsive #statsColumn, #actionsColumn, #townColumn, #actionLogContainer`) to ensure it forms a distinct, proper flex container column.
- Reduced the minimal `600px` top row layout gap in the Tablet grid configuration so the bottom row stays reachable and in frame.
- Re-enabled internal scrolling (`overflow-y: auto`) for primary column panels in Tablet view instead of relying purely on page/`overflow: initial` height expansion.

Verified against standard runtime metrics for 1280x720 (Desktop) and 1024x768 (Tablet) populated footprints, confirming positive bounds, full visibility, and no breakage. Tests run natively and passing.

---
*PR created automatically by Jules for task [16409395846355277550](https://jules.google.com/task/16409395846355277550) started by @wenhuorongbing-netizen*