### PR TITLE
Fix secondary pane visibility on tablet viewports

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -5581,24 +5581,30 @@ select.bold:focus {
     .responsive body.ui-preset-classic #actionsColumn {
         grid-area: actions;
         margin: 0;
+        width: 100%;
+        max-width: 100%;
+        overflow-x: hidden;
     }
 
     .responsive body.ui-preset-classic #townColumn {
         display: flex;
+        flex-direction: column;
+        overflow-y: auto;
         grid-area: town;
-    }
-
-    .responsive body.ui-preset-classic #shortTownColumn {
-        display: none;
+        margin: 0;
+        width: 100%;
+        max-width: 100%;
+        overflow-x: hidden;
     }
 
     .responsive body.ui-preset-classic #statsColumn {
         grid-area: stats;
+        margin: 0;
+        width: 100%;
+        max-width: 100%;
+        overflow-x: hidden;
     }
 
-    .responsive body.ui-preset-classic #actionLogContainer {
-        display: none;
-    }
 }
 
 .responsive body.ui-preset-classic #timeInfo {


### PR DESCRIPTION
This commit addresses Issue #95 by restoring the visibility of the right-side secondary pane (specifically `#shortTownColumn` and `#actionLogContainer`) on tablet/narrow viewports (811px-1300px) in the classic preset layout.

**Key Changes:**
1.  **Restored Visibility:** Removed the `display: none` CSS rules that were hiding the town browser and action log on tablet-sized screens in `stylesheet.css`.
2.  **Layout Adjustments:** Modified the `#townColumn` to be a flex container with vertical flow and internal scrolling (`flex-direction: column`, `overflow-y: auto`) to ensure the newly visible content fits within the layout without breaking the grid.
3.  **Horizontal Overflow Fix:** While restoring the columns, the layout initially triggered horizontal overflow failures in the project's automated `npm run smoke` tests at the 1024px viewport width. This was resolved by applying `width: 100%`, `max-width: 100%`, and `overflow-x: hidden` to the three main columns (`#actionsColumn`, `#townColumn`, `#statsColumn`) within the target media query, effectively preventing them from breaking out of the viewport bounds.

**Validation:**
- Visually verified via fresh Playwright runtime checks on a local server. The town browser, info cards, action log, and overall layout are visible and usable on tablet viewports without obscuring other content.
- `npm run smoke` passes cleanly, confirming no horizontal overflow regressions.
- `npm run regression` and `npm run fixtures:review` complete successfully, maintaining baseline integrity.

These targeted CSS fixes provide a stable and accessible layout for the secondary pane on narrow screens without resorting to legacy metrics or large-scale redesigns.

---
*PR created automatically by Jules for task [2096383737095843089](https://jules.google.com/task/2096383737095843089) started by @wenhuorongbing-netizen*