### PR TITLE
Fix desktop visibility of town browser and action log in classic preset

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -5598,7 +5598,7 @@ select.bold:focus {
     }
 
     .responsive body.ui-preset-classic #shortTownColumn {
-        display: none;
+        display: flex;
     }
 
     .responsive body.ui-preset-classic #statsColumn {
@@ -5606,7 +5606,7 @@ select.bold:focus {
     }
 
     .responsive body.ui-preset-classic #actionLogContainer {
-        display: none;
+        display: flex;
     }
 }
 


### PR DESCRIPTION
Fixes desktop layout visibility issues for `#shortTownColumn` and `#actionLogContainer` in the `classic` UI preset.

**Summary:**
- Identified that `stylesheet.css` incorrectly hid both elements for `.responsive body.ui-preset-classic` under `@media (min-width: 811px) and (max-width: 1300px)`.
- Replaced `display: none;` with `display: flex;` for `#shortTownColumn` and `#actionLogContainer` in these selectors.
- Evaluated desktop viewports (e.g., 1280x720, 1400x900) and verified that the town browser, town actions, and action log now render robustly with nonzero dimensions alongside the main UI track without horizontal overlap or requiring users to hunt for them.
- Tablet/narrow mobile repair behavior is deferred as per scope limits.

---
*PR created automatically by Jules for task [1473662059582217266](https://jules.google.com/task/1473662059582217266) started by @wenhuorongbing-netizen*