### PR TITLE
Fix desktop visibility of town browser and action log in classic preset

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -5598,7 +5598,7 @@ select.bold:focus {
     }
 
     .responsive body.ui-preset-classic #shortTownColumn {
-        display: none;
+        display: flex;
     }
 
     .responsive body.ui-preset-classic #statsColumn {
@@ -5606,7 +5606,7 @@ select.bold:focus {
     }
 
     .responsive body.ui-preset-classic #actionLogContainer {
-        display: none;
+        display: flex;
     }
 }
 


### PR DESCRIPTION
Fix desktop visibility of town browser and action log in classic preset

Removed `display: none` from `#shortTownColumn` and `#actionLogContainer`
in `.responsive body.ui-preset-classic` to ensure secondary pane components
are visible and have a valid layout footprint at desktop resolutions.

---
*PR created automatically by Jules for task [731338285617679729](https://jules.google.com/task/731338285617679729) started by @wenhuorongbing-netizen*