### PR TITLE
Task: Compact secondary top-shell decks into a denser first-screen row

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,14 +63,16 @@
                 <div id="runVitals" aria-live="polite"></div>
                 <div id='timeControls'></div>
             </div>
-            <details id="resourceDeck">
-                <summary id="resourceDeckToggle">RESOURCES</summary>
-                <div id='trackedResources'></div>
-            </details>
-            <details id="menuDeck">
-                <summary id="menuDeckLabel"></summary>
-                <menu id='menu' style='float: left; height: 30px; margin-left: 24px; margin-right: -24px;'></menu>
-            </details>
+            <div id="secondaryDecks">
+                <details id="resourceDeck">
+                    <summary id="resourceDeckToggle">RESOURCES</summary>
+                    <div id='trackedResources'></div>
+                </details>
+                <details id="menuDeck">
+                    <summary id="menuDeckLabel"></summary>
+                    <menu id='menu' style='float: left; height: 30px; margin-left: 24px; margin-right: -24px;'></menu>
+                </details>
+            </div>
         </div>
     </header>
 

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -145,9 +145,16 @@ body {
     padding: 2px 4px;
 }
 
+#secondaryDecks {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 2px;
+}
+
 #runStatusDeck,
 #resourceDeck,
-#menuDeck {
+#menuDeck,
+#secondaryDecks > details {
     border: 1px solid color-mix(in srgb, var(--input-border) 76%, transparent);
     border-radius: 12px;
     background:
@@ -365,12 +372,12 @@ body {
     display: flex;
     align-items: center;
     flex-wrap: wrap;
-    gap: 8px;
-    padding: 4px 10px;
+    gap: 4px;
+    padding: 2px 6px;
 }
 
 #resourceDeck {
-    padding: 4px 10px;
+    padding: 2px 6px;
 }
 
 #resourceDeck #trackedResources {
@@ -381,8 +388,8 @@ body {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    gap: 10px;
-    padding: 4px 8px;
+    gap: 8px;
+    padding: 2px 6px;
     cursor: pointer;
     user-select: none;
     background-color: var(--button-background);
@@ -5199,7 +5206,8 @@ body.ui-density-large .chronicleStoryUnread {
         & #menuDeck,
         & #resourceDeck,
         & #runStatusDeck,
-        & #timeControlsOptionsCard {
+        & #timeControlsOptionsCard,
+        & #secondaryDecks > details {
             border-radius: 14px;
             padding: 2px 4px;
             min-width: 0;


### PR DESCRIPTION
The broader top-shell compaction task in #101 failed while trying to address many shell areas at once. A safer next step is to reduce only the secondary top-shell footprint: `#resourceDeck` and `#menuDeck`, plus their immediate spacing relationship to the surrounding command shell. These areas are good candidates for denser layout because they are not the core start/pause/time controls, but they still contribute to first-screen chrome height.

In scope:
- Inspect the current `index.html` and `stylesheet.css` structure for `#resourceDeck` and `#menuDeck` on the authoritative `new-horizon` baseline.
- Reduce vertical footprint for `#resourceDeck` and `#menuDeck` using small HTML/CSS changes only.
- Prefer denser rows, reduced headings/copy, tighter padding/gaps, wrapping controls more efficiently, or a compact/collapsible secondary menu treatment if appropriate.
- Preserve immediate visibility and usability of critical run controls outside this task, especially time/run controls.
- Measure the primary action/town gameplay workspace selector before and after the change, but only claim improvement caused by this targeted secondary-deck compaction.
- Preserve the current visual direction; do not redesign the full top shell.

Before Height (1024x768): 203.8px
After Height (1024x768): 157.8px

---
*PR created automatically by Jules for task [8865293781828055533](https://jules.google.com/task/8865293781828055533) started by @wenhuorongbing-netizen*