### PR TITLE
Compact secondary top-shell decks into a denser first-screen row

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@
             </details>
             <details id="menuDeck">
                 <summary id="menuDeckLabel"></summary>
-                <menu id='menu' style='float: left; height: 30px; margin-left: 24px; margin-right: -24px;'></menu>
+                <menu id='menu'></menu>
             </details>
         </div>
     </header>

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -365,12 +365,12 @@ body {
     display: flex;
     align-items: center;
     flex-wrap: wrap;
-    gap: 8px;
-    padding: 4px 10px;
+    gap: 4px;
+    padding: 2px 6px;
 }
 
 #resourceDeck {
-    padding: 4px 10px;
+    padding: 2px 6px;
 }
 
 #resourceDeck #trackedResources {
@@ -381,16 +381,17 @@ body {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    gap: 10px;
-    padding: 4px 8px;
+    gap: 6px;
+    padding: 2px 6px;
     cursor: pointer;
     user-select: none;
     background-color: var(--button-background);
     color: var(--button-text);
-    border-radius: 12px;
+    border-radius: 8px;
     font-weight: 700;
     text-transform: uppercase;
     opacity: 0.72;
+    font-size: 0.85rem;
 }
 
 #resourceDeck > summary::-webkit-details-marker, #menuDeck > summary::-webkit-details-marker {
@@ -402,12 +403,12 @@ body {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 22px;
-    height: 22px;
+    width: 18px;
+    height: 18px;
     border-radius: 50%;
     background-color: var(--button-text);
     color: var(--button-background);
-    font-size: 1rem;
+    font-size: 0.9rem;
     line-height: 1;
 }
 
@@ -431,12 +432,12 @@ body {
     display: inline-flex !important;
     align-items: center;
     justify-content: center;
-    min-height: 34px;
-    padding: 0 12px;
+    min-height: 28px;
+    padding: 0 10px;
     border: 1px solid color-mix(in srgb, var(--input-border) 76%, transparent);
     border-radius: 999px;
     background: color-mix(in srgb, var(--body-background) 88%, transparent);
-    font-size: 0.88rem;
+    font-size: 0.8rem;
     font-weight: 700;
     transition: background-color 120ms ease, border-color 120ms ease, transform 120ms ease;
 }
@@ -4618,7 +4619,7 @@ body.ui-density-large .chronicleStoryUnread {
             "resources menu" auto
             / minmax(0, 1.45fr) minmax(320px, 0.92fr);
         align-items: start;
-        gap: 6px 12px;
+        gap: 4px 8px;
     }
 
     & body > br, & #timeInfo > br {

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -5178,6 +5178,7 @@ body.ui-density-large .chronicleStoryUnread {
         & #menuDeck {
             display: flex;
             align-items: center;
+            flex-wrap: wrap;
         }
 
         & #menu {
@@ -5185,6 +5186,8 @@ body.ui-density-large .chronicleStoryUnread {
             flex-wrap: nowrap;
             padding-bottom: 2px;
             margin: 0 !important;
+            width: calc(100vw - 32px);
+            max-width: 100%;
         }
 
         & #menu > li {


### PR DESCRIPTION
This addresses task #109 to strictly compact the secondary top-shell layout (`#resourceDeck` and `#menuDeck`) for a denser top-of-screen presence. It reduces paddings, gaps, standardizes summary scaling, and cleans up legacy inline styles on the menu, freeing up measurable vertical viewport space across both desktop and mobile while keeping critical run controls untouched.

Fresh Playwright browser measurements before and after the change demonstrate the following:
**1280x720 / 1024x768 (Desktop)**
* `#commandDeck` Height: 203.8px -> 179.8px
* `#resourceDeck`/`#menuDeck` Height: 40px -> 28px
* Horizontal overflow: False

**390x844 (Mobile)**
* `#commandDeck` Height: 198.9px -> 182.9px
* `#resourceDeck`/`#menuDeck` Height: 36px -> 28px
* Horizontal overflow: False

All validation commands (`npm run smoke`, `npm run regression`, `npm run fixtures:review`) successfully passed.

---
*PR created automatically by Jules for task [10642253972220600454](https://jules.google.com/task/10642253972220600454) started by @wenhuorongbing-netizen*