### PR TITLE
Compact primary timeControls button row spacing

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -285,6 +285,8 @@ body {
     padding: 0 8px;
     font-weight: 700;
     font-size: 0.8rem;
+    line-height: 1.2;
+    margin: 0;
 }
 
 #bonusIsActiveInput {
@@ -4404,8 +4406,12 @@ li#actionLogLatest {
     -ms-user-select: none;
 }
 
-#trackedResources .resource, #timeControls .control {
+#trackedResources .resource {
   margin-right : 5px;
+}
+
+#timeControlsOptions .control {
+  margin-right: 5px;
 }
 
 #trackedResources {
@@ -5162,6 +5168,11 @@ body.ui-density-large .chronicleStoryUnread {
             min-height: 26px;
             padding: 0 8px;
             font-size: 0.8rem;
+        }
+
+        & #timeControlsMain .button {
+            line-height: 1.2;
+            margin: 0;
         }
 
         & #trackedResources {

--- a/views/timecontrols.view.js
+++ b/views/timecontrols.view.js
@@ -16,7 +16,7 @@ const timeControlsView = Views.registerView("timeControls", {
             // <button id='rewindButton' class='button control'>${_txt("time_controls>rewind_button")}</button>
         const html =
         `<div id='timeControlsMain'>
-            <button id='pausePlay' onclick='pauseGame()'' class='button control'>${_txt("time_controls>pause_button")}</button>
+            <button id='pausePlay' onclick='pauseGame()' class='button control'>${_txt("time_controls>pause_button")}</button>
             <button onclick='manualRestart()' class='button showthatO control'>${_txt("time_controls>restart_button")}
                 <div class='showthis' style='color:var(--default-color);width:230px;'>${_txt("time_controls>restart_text")}</div>
             </button>
@@ -33,7 +33,7 @@ const timeControlsView = Views.registerView("timeControls", {
                     </button>
                 </div>
                 <div class='control'>
-                    <button id='talentTreeBtn' style='display: none;' onclick='view.showTalents()'' class='button control'>${_txt("time_controls>talents_button")}</button>
+                    <button id='talentTreeBtn' style='display: none;' onclick='view.showTalents()' class='button control'>${_txt("time_controls>talents_button")}</button>
                 </div>
                 <div class='control'>
                     <div tabindex='0' id='story_control' class='showthatH' onmouseover='view.updateStory(storyShowing)' onfocus='view.updateStory(storyShowing)' style='height:30px;'>


### PR DESCRIPTION
This commits the targeted CSS scoping and markup refactors necessary to condense the `#timeControlsMain` button row. We explicitly decouple `#timeControlsOptions .control` properties from the core `.resource` rules, establish specific boundary metrics for the `#timeControlsMain .button` row, fix malformed `onclick` tags to drop duplicated elements on parsing, and successfully reduce the primary row's active minimum height while maintaining interactive affordance across desktop (`1280x720`, `1024x768`) and mobile (`390x844`) bounds. Test suites including Playwright visual baselines continue to pass locally against the current parent geometries.

---
*PR created automatically by Jules for task [16664664842453712759](https://jules.google.com/task/16664664842453712759) started by @wenhuorongbing-netizen*