### PR TITLE
Compact top-shell entry path on new-horizon

### DIFF
--- a/output/probe/baseline.json
+++ b/output/probe/baseline.json
@@ -1,0 +1,170 @@
+{
+  "meta": {
+    "branch": "new-horizon",
+    "head": "958ba4b8a33e2df24b32adb8b0a188d1cf77d113",
+    "runDir": "unknown",
+    "command": "node /home/jules/verification/probe.mjs",
+    "timestamp": "2026-05-01T16:19:18.850Z"
+  },
+  "observations": {
+    "desktop-1280x720": {
+      "selectors": {
+        "#commandDeck": {
+          "top": 2,
+          "left": 10,
+          "width": 1259.984375,
+          "height": 179.84375,
+          "bottom": 181.84375
+        },
+        "#timeInfo": {
+          "top": 0,
+          "left": 0,
+          "width": 1279.984375,
+          "height": 185.84375,
+          "bottom": 185.84375
+        },
+        "#runStatusDeck": {
+          "top": 14,
+          "left": 10,
+          "width": 1259.984375,
+          "height": 107.84375,
+          "bottom": 121.84375
+        },
+        "#runVitals": {
+          "top": 17,
+          "left": 15,
+          "width": 1249.984375,
+          "height": 51.84375,
+          "bottom": 68.84375
+        },
+        "#actionsColumn": {
+          "top": 185.84375,
+          "left": 0,
+          "width": 361.875,
+          "height": 534.15625,
+          "bottom": 720
+        },
+        "#mainColumn": null
+      },
+      "criticalControls": {
+        "#timeControls": {
+          "visible": true,
+          "rect": {
+            "top": 70.84375,
+            "left": 15,
+            "width": 1249.984375,
+            "height": 48
+          }
+        }
+      },
+      "visibleText": {},
+      "actionsColumnReachabilityTop": 185.84375
+    },
+    "laptop-1024x768": {
+      "selectors": {
+        "#commandDeck": {
+          "top": 2,
+          "left": 10,
+          "width": 1003.984375,
+          "height": 179.84375,
+          "bottom": 181.84375
+        },
+        "#timeInfo": {
+          "top": 0,
+          "left": 0,
+          "width": 1023.984375,
+          "height": 185.84375,
+          "bottom": 185.84375
+        },
+        "#runStatusDeck": {
+          "top": 14,
+          "left": 10,
+          "width": 1003.984375,
+          "height": 107.84375,
+          "bottom": 121.84375
+        },
+        "#runVitals": {
+          "top": 17,
+          "left": 15,
+          "width": 993.984375,
+          "height": 51.84375,
+          "bottom": 68.84375
+        },
+        "#actionsColumn": {
+          "top": 185.84375,
+          "left": 0,
+          "width": 289.5,
+          "height": 582.15625,
+          "bottom": 768
+        },
+        "#mainColumn": null
+      },
+      "criticalControls": {
+        "#timeControls": {
+          "visible": true,
+          "rect": {
+            "top": 70.84375,
+            "left": 15,
+            "width": 993.984375,
+            "height": 48
+          }
+        }
+      },
+      "visibleText": {},
+      "actionsColumnReachabilityTop": 185.84375
+    },
+    "mobile-390x844": {
+      "selectors": {
+        "#commandDeck": {
+          "top": 1,
+          "left": 4,
+          "width": 382,
+          "height": 182.921875,
+          "bottom": 183.921875
+        },
+        "#timeInfo": {
+          "top": 0,
+          "left": 0,
+          "width": 390,
+          "height": 185.921875,
+          "bottom": 185.921875
+        },
+        "#runStatusDeck": {
+          "top": 11,
+          "left": 4,
+          "width": 382,
+          "height": 112.921875,
+          "bottom": 123.921875
+        },
+        "#runVitals": {
+          "top": 14,
+          "left": 9,
+          "width": 372,
+          "height": 48.921875,
+          "bottom": 62.921875
+        },
+        "#actionsColumn": {
+          "top": 185.921875,
+          "left": 404,
+          "width": 390,
+          "height": 646.15625,
+          "bottom": 832.078125
+        },
+        "#mainColumn": null
+      },
+      "criticalControls": {
+        "#timeControls": {
+          "visible": true,
+          "rect": {
+            "top": 64.921875,
+            "left": 9,
+            "width": 372,
+            "height": 56
+          }
+        }
+      },
+      "visibleText": {},
+      "actionsColumnReachabilityTop": 185.921875
+    }
+  }
+}

--- a/output/probe/post-change.json
+++ b/output/probe/post-change.json
@@ -1,0 +1,170 @@
+{
+  "meta": {
+    "branch": "new-horizon",
+    "head": "958ba4b8a33e2df24b32adb8b0a188d1cf77d113",
+    "runDir": "unknown",
+    "command": "node /home/jules/verification/probe-post.mjs",
+    "timestamp": "2026-05-01T16:29:08.974Z"
+  },
+  "observations": {
+    "desktop-1280x720": {
+      "selectors": {
+        "#commandDeck": {
+          "top": 0,
+          "left": 10,
+          "width": 1259.984375,
+          "height": 167.0625,
+          "bottom": 167.0625
+        },
+        "#timeInfo": {
+          "top": 0,
+          "left": 0,
+          "width": 1279.984375,
+          "height": 169.0625,
+          "bottom": 169.0625
+        },
+        "#runStatusDeck": {
+          "top": 12,
+          "left": 10,
+          "width": 1259.984375,
+          "height": 95.0625,
+          "bottom": 107.0625
+        },
+        "#runVitals": {
+          "top": 13,
+          "left": 15,
+          "width": 1249.984375,
+          "height": 43.0625,
+          "bottom": 56.0625
+        },
+        "#actionsColumn": {
+          "top": 169.0625,
+          "left": 0,
+          "width": 361.875,
+          "height": 550.9375,
+          "bottom": 720
+        },
+        "#mainColumn": null
+      },
+      "criticalControls": {
+        "#timeControls": {
+          "visible": true,
+          "rect": {
+            "top": 58.0625,
+            "left": 15,
+            "width": 1249.984375,
+            "height": 48
+          }
+        }
+      },
+      "visibleText": {},
+      "actionsColumnReachabilityTop": 169.0625
+    },
+    "laptop-1024x768": {
+      "selectors": {
+        "#commandDeck": {
+          "top": 0,
+          "left": 10,
+          "width": 1003.984375,
+          "height": 167.0625,
+          "bottom": 167.0625
+        },
+        "#timeInfo": {
+          "top": 0,
+          "left": 0,
+          "width": 1023.984375,
+          "height": 169.0625,
+          "bottom": 169.0625
+        },
+        "#runStatusDeck": {
+          "top": 12,
+          "left": 10,
+          "width": 1003.984375,
+          "height": 95.0625,
+          "bottom": 107.0625
+        },
+        "#runVitals": {
+          "top": 13,
+          "left": 15,
+          "width": 993.984375,
+          "height": 43.0625,
+          "bottom": 56.0625
+        },
+        "#actionsColumn": {
+          "top": 169.0625,
+          "left": 0,
+          "width": 289.5,
+          "height": 598.9375,
+          "bottom": 768
+        },
+        "#mainColumn": null
+      },
+      "criticalControls": {
+        "#timeControls": {
+          "visible": true,
+          "rect": {
+            "top": 58.0625,
+            "left": 15,
+            "width": 993.984375,
+            "height": 48
+          }
+        }
+      },
+      "visibleText": {},
+      "actionsColumnReachabilityTop": 169.0625
+    },
+    "mobile-390x844": {
+      "selectors": {
+        "#commandDeck": {
+          "top": 1,
+          "left": 4,
+          "width": 382,
+          "height": 178.921875,
+          "bottom": 179.921875
+        },
+        "#timeInfo": {
+          "top": 0,
+          "left": 0,
+          "width": 390,
+          "height": 181.921875,
+          "bottom": 181.921875
+        },
+        "#runStatusDeck": {
+          "top": 11,
+          "left": 4,
+          "width": 382,
+          "height": 108.921875,
+          "bottom": 119.921875
+        },
+        "#runVitals": {
+          "top": 14,
+          "left": 9,
+          "width": 372,
+          "height": 44.921875,
+          "bottom": 58.921875
+        },
+        "#actionsColumn": {
+          "top": 181.921875,
+          "left": 404,
+          "width": 390,
+          "height": 646.15625,
+          "bottom": 828.078125
+        },
+        "#mainColumn": null
+      },
+      "criticalControls": {
+        "#timeControls": {
+          "visible": true,
+          "rect": {
+            "top": 60.921875,
+            "left": 9,
+            "width": 372,
+            "height": 56
+          }
+        }
+      },
+      "visibleText": {},
+      "actionsColumnReachabilityTop": 181.921875
+    }
+  }
+}

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -116,7 +116,7 @@ body {
 #timeInfo {
     display: flex;
     justify-content: center;
-    padding: 2px 10px 4px;
+    padding: 0 10px 2px;
     background: linear-gradient(var(--body-background) 78%, var(--body-background-transparent) 100%);
     position: sticky;
     top: 0;
@@ -125,7 +125,7 @@ body {
 
 #commandDeck {
     display: grid;
-    gap: 2px;
+    gap: 0;
     width: min(100%, 1360px);
 }
 
@@ -142,7 +142,7 @@ body {
     grid-template-columns: minmax(0, 1.45fr) minmax(280px, 0.9fr);
     gap: 2px;
     align-items: center;
-    padding: 2px 4px;
+    padding: 0 4px;
 }
 
 #runStatusDeck,
@@ -223,10 +223,10 @@ body {
     display: flex;
     flex-wrap: wrap;
     column-gap: 6px;
-    row-gap: 2px;
+    row-gap: 0;
     align-items: baseline;
     min-height: auto;
-    padding: 2px 4px;
+    padding: 0 4px;
     border: 1px solid color-mix(in srgb, var(--input-border) 74%, transparent);
     border-radius: 8px;
     background:
@@ -250,7 +250,7 @@ body {
 
 .runVitalValue {
     flex: 1 1 100%;
-    font-size: 0.85rem;
+    font-size: 0.8rem;
     font-weight: 800;
     line-height: 1.1;
 }


### PR DESCRIPTION
This change compacts the top-shell entry path for the application, specifically adjusting the padding, margins, and gaps for `#commandDeck`, `#timeInfo`, `#runStatusDeck`, and `.runVitalCard` elements.

By streamlining the vertical space taken by these elements, the primary action/town workspace (measured by the top boundary of `#actionsColumn`) is made easier to reach and provides more vertical screen real estate for the game loop and action queue. The change ensures the critical text, localization strings, and immediately necessary controls remain fully visible without relying on older, arbitrary layout breakpoints or targets. 

Raw JSON evidence artifacts (`output/probe/baseline.json` and `output/probe/post-change.json`) have been included. The probe validates that the top of `#actionsColumn` moved up securely, e.g. from ~185.8px to ~169.0px on a standard desktop viewport, all while preserving essential interactive controls.

Tests (`npm run smoke` and `npm run regression`) pass locally, confirming no core functionality or layout constraints were broken.

---
*PR created automatically by Jules for task [11134647272128426487](https://jules.google.com/task/11134647272128426487) started by @wenhuorongbing-netizen*